### PR TITLE
add getter for different figures types

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake build-essential
+          sudo apt-get install -y cmake build-essential valgrind
 
       - name: Cache CMake build
         uses: actions/cache@v3
@@ -46,3 +46,6 @@ jobs:
 
       - name: Run tests
         run: ctest --test-dir build --output-on-failure
+
+      - name: Run valgrind on all tests
+        run: bash scripts/run_valgrind_all.sh build

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,25 @@
+# Сборка OurPaintDCM с MinGW (MSYS2 UCRT64)
+# Запускайте из PowerShell после добавления ucrt64 в PATH:
+#   $env:Path += ";C:\msys64\ucrt64\bin"
+
+$ErrorActionPreference = "Stop"
+
+# Добавляем MinGW в PATH, если ещё не добавлен
+if (-not (Get-Command g++ -ErrorAction SilentlyContinue)) {
+    $env:Path += ";C:\msys64\ucrt64\bin"
+}
+
+# Удаляем старый build (очистка кэша CMake)
+if (Test-Path build) {
+    Remove-Item -Recurse -Force build
+}
+
+# Конфигурация с MinGW + Ninja
+cmake -G "Ninja" `
+    -DCMAKE_CXX_COMPILER="C:\msys64\ucrt64\bin\g++.exe" `
+    -DCMAKE_C_COMPILER="C:\msys64\ucrt64\bin\gcc.exe" `
+    -DCMAKE_MAKE_PROGRAM="C:\msys64\ucrt64\bin\ninja.exe" `
+    -S . -B build
+
+# Сборка
+cmake --build build

--- a/headers/DCMManager.h
+++ b/headers/DCMManager.h
@@ -94,6 +94,30 @@ public:
     std::vector<Utils::FigureDescriptor> getAllFigures() const;
 
     /**
+     * @brief Get all point descriptors.
+     * @return Vector of FigureDescriptors for all points.
+     */
+    std::vector<Utils::FigureDescriptor> getAllPoints() const;
+
+    /**
+     * @brief Get all line descriptors.
+     * @return Vector of FigureDescriptors for all lines.
+     */
+    std::vector<Utils::FigureDescriptor> getAllLines() const;
+
+    /**
+     * @brief Get all circle descriptors.
+     * @return Vector of FigureDescriptors for all circles.
+     */
+    std::vector<Utils::FigureDescriptor> getAllCircles() const;
+
+    /**
+     * @brief Get all arc descriptors.
+     * @return Vector of FigureDescriptors for all arcs.
+     */
+    std::vector<Utils::FigureDescriptor> getAllArcs() const;
+
+    /**
      * @brief Add a new requirement using descriptor.
      * @param descriptor RequirementDescriptor containing requirement data.
      * @return ID of the created requirement.

--- a/headers/DCMManager.h
+++ b/headers/DCMManager.h
@@ -28,6 +28,9 @@ using ComponentGraph = Graph<Utils::ID, Utils::ID, UndirectedPolicy, WeightedPol
  *
  * Provides unified CRUD operations for geometric figures and requirements.
  * Manages connected components of the constraint graph.
+ *
+ * Change geometry through addFigure / removeFigure / update*; inspect it via getStorage().
+ * Mutable storage() is an escape hatch only; the caller bears all consequences (see that method’s docs).
  */
 class DCMManager {
 public:
@@ -194,8 +197,8 @@ public:
     std::vector<std::vector<Utils::ID>> getAllComponents() const;
 
     /**
-     * @brief Get read-only access to GeometryStorage.
-     * @return Const reference to internal GeometryStorage.
+     * @brief Read-only access to GeometryStorage (preferred, safe path).
+     * @return Const reference; geometry cannot be modified through this accessor.
      */
     const Figures::GeometryStorage& getStorage() const noexcept;
 
@@ -206,8 +209,12 @@ public:
     const System::RequirementSystem& getRequirementSystem() const noexcept;
 
     /**
-     * @brief Get mutable access to GeometryStorage.
-     * @return Reference to internal GeometryStorage.
+     * @brief Mutable GeometryStorage access — use only when absolutely necessary.
+     *
+     * @warning Normal code should use addFigure, removeFigure, updatePoint, updateCircle, and getStorage().
+     * Direct mutation bypasses manager invariants: _figureRecords, connected components, and RequirementSystem
+     * consistency. Restoring a coherent state is entirely the caller's responsibility. Any risk of broken solvers,
+     * stale IDs, or undefined behaviour is solely on the code that calls this method.
      */
     Figures::GeometryStorage& storage() noexcept;
 
@@ -218,8 +225,9 @@ public:
     System::RequirementSystem& requirementSystem() noexcept;
 
     /**
-     * @brief Get total figure count.
-     * @return Number of figures.
+     * @brief Number of objects in GeometryStorage (getStorage().size()).
+     *
+     * Tracks the canonical geometry set; keeps agreement with hasFigure / removeFigure when records and storage stay in sync.
      */
     std::size_t figureCount() const noexcept;
 
@@ -270,6 +278,8 @@ private:
     std::unique_ptr<System::RequirementSystem> buildSubsystem(ComponentID componentId) const;
 
     void rebuildRequirementSystem();
+    /** Drops requirement records whose objectIds reference IDs no longer in GeometryStorage; rebuilds the system if needed. */
+    void pruneRequirementsWithMissingObjects();
     void rebuildComponents();
     void mergeComponents(const std::vector<Utils::ID>& figureIds);
     void splitComponentsAfterRemoval();

--- a/headers/figures/GeometryDependencyIndex.h
+++ b/headers/figures/GeometryDependencyIndex.h
@@ -1,0 +1,83 @@
+#ifndef OURPAINTDCM_HEADERS_FIGURES_GEOMETRYDEPENDENCYINDEX_H
+#define OURPAINTDCM_HEADERS_FIGURES_GEOMETRYDEPENDENCYINDEX_H
+
+#include "ID.h"
+
+#include <unordered_map>
+#include <vector>
+
+namespace OurPaintDCM::Figures {
+
+/**
+ * @brief Bidirectional adjacency for point↔figure incidence.
+ *
+ * - point → figures that reference that point (for getDependents-style queries).
+ * - figure → point IDs it depends on (endpoints / center), fixed small arity.
+ *
+ * Updates are local to the arity k of the figure (O(k)); no full storage scan.
+ */
+class GeometryDependencyIndex {
+public:
+    /**
+     * @brief Registers a line and links @p lineId to endpoints @p p1, @p p2.
+     */
+    void linkLine(Utils::ID lineId, Utils::ID p1, Utils::ID p2);
+
+    /**
+     * @brief Registers a circle; @p center is the only incident point ID in the index.
+     */
+    void linkCircle(Utils::ID circleId, Utils::ID center);
+
+    /**
+     * @brief Registers an arc through @p p1, @p p2 with center @p center.
+     */
+    void linkArc(Utils::ID arcId, Utils::ID p1, Utils::ID p2, Utils::ID center);
+
+    /**
+     * @brief Removes @p figureId from both directions: drops figure→points and
+     *        removes the figure from each point’s incident list (cleans empty point entries).
+     */
+    void unlinkFigure(Utils::ID figureId);
+
+    /**
+     * @brief Copy of all figure IDs incident on @p pointId (lines/circles/arcs using this point).
+     * @return Empty if the point has no incidents or is unknown.
+     */
+    [[nodiscard]] std::vector<Utils::ID> dependentsOfPoint(Utils::ID pointId) const;
+
+    /**
+     * @brief Const reference to the stored point-ID list for @p figureId (arity 1–3).
+     * @return Empty static vector if @p figureId is unknown; do not store the reference
+     *         beyond the index’s lifetime or across mutating calls on this index.
+     */
+    [[nodiscard]] const std::vector<Utils::ID>& pointsForFigure(Utils::ID figureId) const noexcept;
+
+    /**
+     * @brief True if @p pointId has at least one incident figure in the index.
+     */
+    [[nodiscard]] bool hasDependents(Utils::ID pointId) const noexcept;
+
+    /**
+     * @brief True if @p figureId has no figure→points entry (not linked or already unlinked).
+     */
+    [[nodiscard]] bool emptyFigure(Utils::ID figureId) const noexcept;
+
+    /**
+     * @brief Clears both maps.
+     */
+    void clear() noexcept;
+
+private:
+    /** @brief Appends @p id to @p vec if not already present (linear scan). */
+    static void pushUnique(std::vector<Utils::ID>& vec, Utils::ID id);
+    /** @brief Removes all occurrences of @p id from @p vec. */
+    static void eraseId(std::vector<Utils::ID>& vec, Utils::ID id);
+
+    std::unordered_map<Utils::ID, std::vector<Utils::ID>> pointToFigures_;
+    std::unordered_map<Utils::ID, std::vector<Utils::ID>> figureToPoints_;
+    static const std::vector<Utils::ID> kEmpty;
+};
+
+} // namespace OurPaintDCM::Figures
+
+#endif

--- a/headers/figures/GeometryGraphBuilder.h
+++ b/headers/figures/GeometryGraphBuilder.h
@@ -1,0 +1,39 @@
+#ifndef OURPAINTDCM_HEADERS_FIGURES_GEOMETRYGRAPHBUILDER_H
+#define OURPAINTDCM_HEADERS_FIGURES_GEOMETRYGRAPHBUILDER_H
+
+#include "Graph.h"
+#include "ID.h"
+
+#include <optional>
+
+// Forward declaration avoids heavy include cycle
+namespace OurPaintDCM::Figures {
+class GeometryStorage;
+}
+
+namespace OurPaintDCM::Figures {
+
+using ObjectGraph = Graph<Utils::ID, Utils::ID, UndirectedPolicy, WeightedPolicy>;
+
+/**
+ * @brief Builds topology graphs using only public GeometryStorage APIs.
+ *
+ * Edge wiring uses getDependencies() per figure — no ad hoc scan of all objects for incidence.
+ */
+class GeometryGraphBuilder {
+public:
+    /**
+     * @brief Full object graph: every live ID as vertex; edges join each figure to its point IDs.
+     */
+    [[nodiscard]] static ObjectGraph buildObjectGraph(const GeometryStorage& storage);
+
+    /**
+     * @brief Local neighbourhood around @p id: vertex @p id, adjacent figures/points, and edges among them.
+     * @return std::nullopt if @p id is not present in @p storage.
+     */
+    [[nodiscard]] static std::optional<ObjectGraph> buildObjectSubgraph(const GeometryStorage& storage, Utils::ID id);
+};
+
+} // namespace OurPaintDCM::Figures
+
+#endif

--- a/headers/figures/GeometryStorage.h
+++ b/headers/figures/GeometryStorage.h
@@ -425,6 +425,17 @@ private:
     std::unordered_map<const Point2D*, ID> m_pointToID;
 
     /**
+     * @brief Fast type-specific ID lookup.
+     * 
+     * Keeps separate ID lists for each figure type so type-based
+     * queries do not have to scan the full index.
+     */
+    std::vector<ID> m_pointIDs;
+    std::vector<ID> m_lineIDs;
+    std::vector<ID> m_circleIDs;
+    std::vector<ID> m_arcIDs;
+
+    /**
      * @brief Convert type T to corresponding FigureType.
      */
     template <SupportedFigure T>

--- a/headers/figures/GeometryStorage.h
+++ b/headers/figures/GeometryStorage.h
@@ -1,19 +1,7 @@
 #ifndef OURPAINTDCM_HEADERS_FIGURES_GEOMETRYSTORAGE_H
 #define OURPAINTDCM_HEADERS_FIGURES_GEOMETRYSTORAGE_H
 
-#include <deque>
-#include <unordered_map>
-#include <optional>
-#include <span>
-#include <string>
-#include <string_view>
-#include <ranges>
-#include <concepts>
-#include <type_traits>
-#include <functional>
-#include <vector>
-#include <stdexcept>
-
+#include "GeometryDependencyIndex.h"
 #include "Point2D.h"
 #include "Line.h"
 #include "Circle.h"
@@ -22,6 +10,14 @@
 #include "IDGenerator.h"
 #include "Enums.h"
 #include "Graph.h"
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+#include <concepts>
+#include <stdexcept>
 
 namespace OurPaintDCM::Figures {
 
@@ -34,10 +30,7 @@ using Arc2D    = Arc<Point2D>;
 using ObjectGraph = Graph<ID, ID, UndirectedPolicy, WeightedPolicy>;
 
 /**
- * @brief Concept to check if a type is a supported geometric figure.
- * 
- * Allows template functions to be used only with allowed types.
- * Errors will be caught at compile time with clear messages.
+ * @brief Types allowed for GeometryStorage::get().
  */
 template <typename T>
 concept SupportedFigure = std::same_as<T, Point2D> ||
@@ -46,25 +39,27 @@ concept SupportedFigure = std::same_as<T, Point2D> ||
                           std::same_as<T, Arc2D>;
 
 /**
- * @brief Structure to store metadata about a geometric object.
- * 
- * Stores:
- * - type: figure type (Point, Line, Circle, Arc)
- * - ptr: raw pointer to object (void* for universality)
- * 
- * Why void*? This allows storing all types in a single unordered_map.
- * When retrieving, we know the type from `type` field and perform safe static_cast.
+ * @brief Outcome of a non-throwing remove operation.
  */
-struct FigureEntry {
-    FigureType type;  ///< Type of geometric object
-    void*      ptr;   ///< Pointer to the object itself
-    
-    constexpr FigureEntry() noexcept : type{}, ptr{nullptr} {}
-    constexpr FigureEntry(FigureType t, void* p) noexcept : type(t), ptr(p) {}
+enum class RemoveResult : std::uint8_t {
+    Ok,                   /**< Object removed; state updated atomically for this call. */
+    NotFound,             /**< No object with this ID (or wrong branch for removeFigureOnly). */
+    BlockedByDependents,  /**< Point still referenced by figures; use forceCascade or delete figures first. */
 };
 
 /**
- * @brief Input data for figure creation without exposing internal types.
+ * @brief Maps a public figure ID to its FigureType and index in the per-type slot pool.
+ */
+struct FigureEntry {
+    FigureType    type{};
+    std::uint32_t slot{};
+
+    constexpr FigureEntry() noexcept = default;
+    constexpr FigureEntry(FigureType t, std::uint32_t s) noexcept : type(t), slot(s) {}
+};
+
+/**
+ * @brief Aggregated coordinates for GeometryStorage::createFigure() (batch / descriptor path).
  */
 struct FigureData {
     struct PointData {
@@ -73,380 +68,278 @@ struct FigureData {
     };
     std::vector<PointData> points{};
     PointData center{};
-    double radius{};
+    double     radius{};
 };
 
+/**
+ * @brief Cached handle for linear iteration: stable ID with a non-owning pointer into storage.
+ *
+ * Pointer remains valid while the object exists and is not removed from this storage.
+ */
+template <typename T>
+struct FigureRef {
+    ID         id{};
+    const T*   ptr{nullptr};
+};
 
 /**
- * @brief Storage for geometric objects with unified identification system.
- 
- * ## Usage Example
- * @code
- * GeometryStorage storage;
- * 
- * // Create points
- * auto [id1, p1] = storage.createPoint(0.0, 5.0);
- * auto [id2, p2] = storage.createPoint(10.0, 5.0);
- * 
- * // Create line between points
- * auto [lineId, line] = storage.createLine(p1, p2);
- * 
- * // Get object by ID
- * Point2D* point = storage.get<Point2D>(id1).value();
- * 
- * // Safe retrieval with type checking
- * auto result = storage.get<Line2D>(lineId);
- * if (result) {
- *     Line2D* myLine = result.value();
- * }
- * @endcode
+ * @brief ID-first 2D geometry store with slot pools and a bidirectional point↔figure dependency index.
+ *
+ * Dependency queries avoid scanning the whole scene: incident figures per point are O(degree)
+ * in the index; each figure keeps a fixed small list of endpoint / center IDs.
  */
 class GeometryStorage {
 public:
-    /**
-     * @brief Default constructor.
-     * 
-     * Creates empty storage with ID generator starting from 1.
-     */
+    /** @brief Constructs an empty storage; IDs start from the generator default. */
     GeometryStorage() = default;
-    
-    /// @brief Default destructor (deque will free memory itself).
+    /** @brief Releases all figures and clears indices. */
     ~GeometryStorage() = default;
-    
-    /// @brief Copying disabled (storage contains unique objects).
+
     GeometryStorage(const GeometryStorage&) = delete;
     GeometryStorage& operator=(const GeometryStorage&) = delete;
-    
-    /// @brief Move allowed.
+    /** @brief Move-constructs; source is left in a valid empty state. */
     GeometryStorage(GeometryStorage&&) noexcept = default;
+    /** @brief Move-assigns; source is left in a valid empty state. */
     GeometryStorage& operator=(GeometryStorage&&) noexcept = default;
-    
+
     /**
-     * @brief Create point with given coordinates.
-     * 
-     * @param x X coordinate
-     * @param y Y coordinate
-     * @return Pair {ID, pointer to created point}
-     * 
-     * Complexity: O(1) amortized (push_back in deque + insert in map)
+     * @brief Creates a point at (x, y).
+     * @return New unique ID for the point.
      */
-    [[nodiscard]] std::pair<ID, Point2D*> createPoint(double x, double y);
-    
+    [[nodiscard]] ID createPoint(double x, double y);
+
     /**
-     * @brief Create line between two points.
-     * 
-     * @param p1 Pointer to first point (must belong to this storage)
-     * @param p2 Pointer to second point
-     * @return Pair {ID, pointer to created line}
-     * 
-     * @warning Passed points must be created in THIS storage.
-     *          Otherwise behavior is undefined on deletion.
+     * @brief Creates a line through two existing points.
+     * @param p1 First endpoint ID (must be ET_POINT2D).
+     * @param p2 Second endpoint ID (must be ET_POINT2D).
+     * @return Line ID, or std::nullopt if either ID is missing or not a point.
      */
-    [[nodiscard]] std::pair<ID, Line2D*> createLine(Point2D* p1, Point2D* p2);
-    
+    [[nodiscard]] std::optional<ID> createLine(ID p1, ID p2);
+
     /**
-     * @brief Create circle.
-     * 
-     * @param center Pointer to center (point from this storage)
-     * @param radius Circle radius
-     * @return Pair {ID, pointer to created circle}
+     * @brief Creates a circle with given center and radius.
+     * @param center Center point ID (must be ET_POINT2D).
+     * @param radius Non-negative radius (semantics validated by Circle type).
+     * @return Circle ID, or std::nullopt if center is invalid.
      */
-    [[nodiscard]] std::pair<ID, Circle2D*> createCircle(Point2D* center, double radius);
-    
+    [[nodiscard]] std::optional<ID> createCircle(ID center, double radius);
+
     /**
-     * @brief Create arc.
-     * 
-     * @param p1 First endpoint of arc
-     * @param p2 Second endpoint of arc
-     * @param center Center of arc
-     * @return Pair {ID, pointer to created arc}
+     * @brief Creates an arc through two points with a center point.
+     * @param p1 First endpoint ID.
+     * @param p2 Second endpoint ID.
+     * @param center Center point ID.
+     * @return Arc ID, or std::nullopt if any ID is missing or not a point.
      */
-    [[nodiscard]] std::pair<ID, Arc2D*> createArc(Point2D* p1, Point2D* p2, Point2D* center);
-    
+    [[nodiscard]] std::optional<ID> createArc(ID p1, ID p2, ID center);
+
     /**
-     * @brief Create figure without exposing concrete types.
-     * 
-     * @param type Figure type to create
-     * @param data Input data (coordinates and radius)
-     * @return ID of created figure
-     * @throws std::runtime_error when data invalid or type unknown
+     * @brief Creates a figure from aggregated FigureData (may create nested points).
+     * @param type Figure kind (point, line, circle, arc).
+     * @param data Coordinates and radius as required by @p type.
+     * @return ID of the top-level created figure (for line/circle/arc) or point.
+     * @throws std::runtime_error if @p data is inconsistent or creation fails.
      */
     [[nodiscard]] ID createFigure(FigureType type, const FigureData& data);
-    
+
     /**
-     * @brief Get object by ID with type checking.
-     * 
-     * @tparam T Expected object type (Point2D, Line2D, Circle2D, Arc2D)
-     * @param id Object identifier
-     * @return T* if found
-     * @throws std::runtime_error if ID missing or type mismatch
-     * 
-     * Complexity: O(1) — lookup in unordered_map
-     * 
+     * @brief Mutable access to a figure by ID and expected type.
+     * @return Pointer into storage, or nullptr if ID missing or type mismatch.
      */
     template <SupportedFigure T>
-    [[nodiscard]] T* get(ID id) const;
-    
+    [[nodiscard]] T* get(ID id) noexcept;
+
     /**
-     * @brief Get object by ID without type checking (unsafe).
-     * 
-     * @param id Object identifier
-     * @return void* or nullptr if not found
-     * 
-     * @warning Caller must know the object type!
-     * 
-     * Useful when type is already known from another source (e.g., from FigureEntry).
+     * @brief Const access to a figure by ID and expected type.
+     * @return Pointer into storage, or nullptr if ID missing or type mismatch.
      */
-    [[nodiscard]] void* getRaw(ID id) const noexcept;
-    
+    template <SupportedFigure T>
+    [[nodiscard]] const T* get(ID id) const noexcept;
+
     /**
-     * @brief Get object type by ID.
-     * 
-     * @param id Object identifier
-     * @return std::optional<FigureType> — type or nullopt if ID not found
+     * @brief Returns the stored FigureType for an ID, if present.
      */
     [[nodiscard]] std::optional<FigureType> getType(ID id) const noexcept;
-    
+
     /**
-     * @brief Get full figure entry.
-     * 
-     * @param id Object identifier
-     * @return std::optional<FigureEntry> — entry or nullopt if not found
+     * @brief Returns the internal FigureEntry (type + pool slot) for diagnostics/tools.
      */
     [[nodiscard]] std::optional<FigureEntry> getEntry(ID id) const noexcept;
-    
+
     /**
-     * @brief Check if object exists.
-     * 
-     * @param id Object identifier
-     * @return true if object exists
+     * @brief True if @p id is currently a live object in this storage.
      */
     [[nodiscard]] bool contains(ID id) const noexcept;
 
     /**
-     * @brief Remove object by ID.
-     * 
-     * @param id Identifier of object to remove
-     * @param forceCascade If true — also removes dependent objects.
-     *                     If false — returns DEPENDENCY_EXISTS error if dependencies exist.
-     * @throws std::runtime_error when ID not found or dependencies block removal
-     * 
-     * ## Algorithm
-     * 1. Check existence
-     * 2. If Point2D, check dependencies (Line/Circle/Arc that use it)
-     * 3. If forceCascade=false and dependencies exist — error
-     * 4. If forceCascade=true — first remove dependent objects
-     * 5. Mark slot in deque as "deleted" (lazy deletion)
-     * 
-     * ## Why lazy deletion?
-     * Real deletion from middle of deque is O(n).
-     * We just remove entry from index. Object remains in memory,
-     * but is inaccessible. Can implement compaction if needed.
+     * @brief Removes an object by ID without throwing.
+     *
+     * For a point: if figures still reference it, returns BlockedByDependents unless
+     * @p forceCascade is true, in which case dependent figures are removed first, then the point.
+     * For a non-point figure: removes only that figure and updates the dependency index.
+     *
+     * @param id Object to remove.
+     * @param forceCascade When true, delete incident figures before deleting a point.
+     * @return RemoveResult describing success or reason for failure.
      */
-    void remove(ID id, bool forceCascade = false);
-    
+    [[nodiscard]] RemoveResult remove(ID id, bool forceCascade = false) noexcept;
+
     /**
-     * @brief Clear entire storage.
-     * 
-     * Removes all objects and resets ID generator.
+     * @brief Removes every object, resets ID generator, clears all indices and free lists.
      */
     void clear() noexcept;
 
     /**
-     * @brief Get span of all points.
-     * 
-     * @return std::span<Point2D> — contiguous view of all points
-     * 
-     * @note Span invalidates when adding new points!
-     *       Use for read-only iteration.
-     */
-    [[nodiscard]] std::span<Point2D> allPoints() noexcept;
-    [[nodiscard]] std::span<const Point2D> allPoints() const noexcept;
-    
-    [[nodiscard]] std::span<Line2D> allLines() noexcept;
-    [[nodiscard]] std::span<const Line2D> allLines() const noexcept;
-    
-    [[nodiscard]] std::span<Circle2D> allCircles() noexcept;
-    [[nodiscard]] std::span<const Circle2D> allCircles() const noexcept;
-    
-    [[nodiscard]] std::span<Arc2D> allArcs() noexcept;
-    [[nodiscard]] std::span<const Arc2D> allArcs() const noexcept;
-    
-    /**
-     * @brief Get all IDs of specified type.
-     * 
-     * @param type Figure type for filtering
-     * @return Vector of IDs of all objects of this type
-     * 
-     * Uses std::ranges for efficient filtering.
+     * @brief Lists all IDs of a given figure type (order matches internal cache order).
+     * @note complexity O(n) for n of that type — intended for enumeration, not hot paths.
      */
     [[nodiscard]] std::vector<ID> getIDsByType(FigureType type) const;
-    
-    /**
-     * @brief Get all entries (ID + Entry).
-     * 
-     * @return Const reference to internal index
-     * 
-     * Allows iterating over all objects:
-     * @code
-     * for (const auto& [id, entry] : storage.allEntries()) {
-     *     std::cout << "ID: " << id.id << ", Type: " << static_cast<int>(entry.type) << "\n";
-     * }
-     * @endcode
-     */
-    [[nodiscard]] const std::unordered_map<ID, FigureEntry>& allEntries() const noexcept;
-    
-    /**
-     * @brief Total number of objects in storage.
-     */
+
+    /** @brief Total number of live objects (all types). */
     [[nodiscard]] std::size_t size() const noexcept;
-    
-    /**
-     * @brief Number of points.
-     */
+    /** @brief Number of live points. */
     [[nodiscard]] std::size_t pointCount() const noexcept;
-    
-    /**
-     * @brief Number of lines.
-     */
+    /** @brief Number of live lines. */
     [[nodiscard]] std::size_t lineCount() const noexcept;
-    
-    /**
-     * @brief Number of circles.
-     */
+    /** @brief Number of live circles. */
     [[nodiscard]] std::size_t circleCount() const noexcept;
-    
-    /**
-     * @brief Number of arcs.
-     */
+    /** @brief Number of live arcs. */
     [[nodiscard]] std::size_t arcCount() const noexcept;
-    
-    /**
-     * @brief Check if empty.
-     */
+    /** @brief True if size() == 0. */
     [[nodiscard]] bool empty() const noexcept;
-    
+
     /**
-     * @brief Get current ID generator value.
-     * 
-     * Useful for serialization/deserialization.
+     * @brief Last issued ID from the internal generator (same as IDGenerator::current()).
      */
     [[nodiscard]] const ID& currentID() const noexcept;
+
     /**
-     * @brief Find all objects depending on given point.
-     * 
-     * @param pointId Point ID
-     * @return Vector of IDs of objects (Line, Circle, Arc) using this point
-     * 
-     * Useful before deleting point to see what will "break".
+     * @brief Figures incident on a point (lines/circles/arcs that use this point).
+     * @param pointId Must reference a point; otherwise returns empty vector.
+     * @return Copy of the index list; cost O(degree) for allocation and copy.
      */
     [[nodiscard]] std::vector<ID> getDependents(ID pointId) const;
-    
+
     /**
-     * @brief Find all points that object depends on.
-     * 
-     * @param id Object ID (Line, Circle, Arc)
-     * @return Vector of IDs of points referenced by object
+     * @brief Point IDs this figure depends on (endpoints / center); empty for points.
+     * @return Copy of stored arity list; lookup O(1), copy O(k) for k endpoints.
      */
     [[nodiscard]] std::vector<ID> getDependencies(ID id) const;
 
     /**
-     * @brief Build graph of objects where vertices are IDs and edges connect related objects.
-     * 
-     * Edge weight is ID(-1) as helper value for connected objects
+     * @brief Full object graph: all vertices plus edges between figures and their points.
      */
     [[nodiscard]] ObjectGraph buildObjectGraph() const;
-    
-    /**
-     * @brief Build shallow subgraph for a given object ID (one-level neighborhood).
-     * 
-     * Includes the object and its direct dependencies/dependents only.
-     * @throws std::runtime_error if ID not found
-     */
-    [[nodiscard]] ObjectGraph buildObjectSubgraph(ID id) const;
 
     /**
-     * @brief Get all active points with their IDs.
-     * @return Vector of pairs {ID, const Point2D*} for all active points.
+     * @brief Local subgraph around @p id: the object, its neighbours, and edges among them.
+     * @return std::nullopt if @p id is not in storage.
      */
-    [[nodiscard]] std::vector<std::pair<ID, const Point2D*>> allPointsWithID() const;
+    [[nodiscard]] std::optional<ObjectGraph> buildObjectSubgraph(ID id) const;
 
-    /**
-     * @brief Get all active lines with their IDs.
-     * @return Vector of pairs {ID, const Line2D*} for all active lines.
-     */
-    [[nodiscard]] std::vector<std::pair<ID, const Line2D*>> allLinesWithID() const;
+    /** @brief Read-only cache of all points for fast iteration (IDs + const pointers). */
+    [[nodiscard]] const std::vector<FigureRef<Point2D>>& pointsWithIds() const noexcept { return m_pointsWithIds; }
+    /** @brief Read-only cache of all lines. */
+    [[nodiscard]] const std::vector<FigureRef<Line2D>>& linesWithIds() const noexcept { return m_linesWithIds; }
+    /** @brief Read-only cache of all circles. */
+    [[nodiscard]] const std::vector<FigureRef<Circle2D>>& circlesWithIds() const noexcept { return m_circlesWithIds; }
+    /** @brief Read-only cache of all arcs. */
+    [[nodiscard]] const std::vector<FigureRef<Arc2D>>& arcsWithIds() const noexcept { return m_arcsWithIds; }
 
+#ifndef NDEBUG
     /**
-     * @brief Get all active circles with their IDs.
-     * @return Vector of pairs {ID, const Circle2D*} for all active circles.
+     * @brief Validates index, caches, slot occupancy, and dependency arity in debug builds.
+     * @return False if any invariant is violated.
      */
-    [[nodiscard]] std::vector<std::pair<ID, const Circle2D*>> allCirclesWithID() const;
+    [[nodiscard]] bool validate() const noexcept;
 
-    /**
-     * @brief Get all active arcs with their IDs.
-     * @return Vector of pairs {ID, const Arc2D*} for all active arcs.
-     */
-    [[nodiscard]] std::vector<std::pair<ID, const Arc2D*>> allArcsWithID() const;
+    /** @brief Point pool vector size (includes free slots); for tests/diagnostics only. */
+    [[nodiscard]] std::size_t debugPointPoolSize() const noexcept { return m_pointSlots.size(); }
+    /** @brief Line pool vector size (includes free slots); for tests/diagnostics only. */
+    [[nodiscard]] std::size_t debugLinePoolSize() const noexcept { return m_lineSlots.size(); }
+#endif
 
 private:
     /**
-     * @brief Storage for each object type.
-     * 
-     * We use deque instead of vector because:
-     * - On push_back, pointers to EXISTING elements are NOT invalidated
-     * - This is critical since Line/Circle/Arc store Point2D*
-     * - Vector on reallocation would move all Point2D, breaking all pointers
+     * @brief Removes a line, circle, or arc by ID; does not delete points.
+     * @return NotFound if id missing, is a point, or unknown type.
      */
-    std::deque<Point2D>  m_points;
-    std::deque<Line2D>   m_lines;
-    std::deque<Circle2D> m_circles;
-    std::deque<Arc2D>    m_arcs;
-    
-    /**
-     * @brief Main index: ID -> (type + pointer).
-     * 
-     * Provides O(1) access to any object by its unique ID.
-     * Hash function for ID is defined in ID.h (std::hash specialization).
-     */
-    std::unordered_map<ID, FigureEntry> m_index;
-    
-    /**
-     * @brief Unique ID generator.
-     * 
-     * Single generator for entire storage all objects get unique ID
-     * from unified sequence.
-     */
-    IDGenerator m_idGen;
-    
-    /**
-     * @brief Reverse index: Point2D* -> ID.
-     */
-    std::unordered_map<const Point2D*, ID> m_pointToID;
+    [[nodiscard]] RemoveResult removeFigureOnly(ID id) noexcept;
 
     /**
-     * @brief Fast type-specific ID lookup.
-     * 
-     * Keeps separate ID lists for each figure type so type-based
-     * queries do not have to scan the full index.
+     * @brief Returns @p id if it names a point; otherwise std::nullopt.
      */
-    std::vector<ID> m_pointIDs;
-    std::vector<ID> m_lineIDs;
-    std::vector<ID> m_circleIDs;
-    std::vector<ID> m_arcIDs;
+    std::optional<ID> tryPointId(ID id) const noexcept;
+
+    /** @brief Appends to per-type iteration cache and position map. */
+    void registerPointCache(ID id, const Point2D* ptr);
+    void registerLineCache(ID id, const Line2D* ptr);
+    void registerCircleCache(ID id, const Circle2D* ptr);
+    void registerArcCache(ID id, const Arc2D* ptr);
+
+    /** @brief Swaps out of dense cache by ID (swap-with-last). */
+    void erasePointCache(ID id) noexcept;
+    void eraseLineCache(ID id) noexcept;
+    void eraseCircleCache(ID id) noexcept;
+    void eraseArcCache(ID id) noexcept;
 
     /**
-     * @brief Convert type T to corresponding FigureType.
+     * @brief Removes one entry from @p cache and keeps @p posMap consistent.
      */
+    template <typename T>
+    static void eraseCachedById(
+        ID id,
+        std::vector<FigureRef<T>>& cache,
+        std::unordered_map<ID, std::size_t>& posMap
+    ) noexcept;
+
+    /** @brief Allocates or reuses a point slot; returns slot index. */
+    std::size_t allocPoint(double x, double y);
+    /** @brief Allocates or reuses a line slot; line stores raw pointers @p a, @p b. */
+    std::size_t allocLine(Point2D* a, Point2D* b);
+    /** @brief Allocates or reuses a circle slot. */
+    std::size_t allocCircle(Point2D* c, double r);
+    /** @brief Allocates or reuses an arc slot. */
+    std::size_t allocArc(Point2D* p1, Point2D* p2, Point2D* c);
+
+    /** @brief Destroys point in slot and pushes slot index onto the point free list. */
+    void freePoint(std::size_t slot);
+    /** @brief Destroys line in slot and pushes slot index onto the line free list. */
+    void freeLine(std::size_t slot);
+    /** @brief Destroys circle in slot and pushes slot index onto the circle free list. */
+    void freeCircle(std::size_t slot);
+    /** @brief Destroys arc in slot and pushes slot index onto the arc free list. */
+    void freeArc(std::size_t slot);
+
+    /** @brief Maps C++ figure type to FigureType enum. */
     template <SupportedFigure T>
     static constexpr FigureType typeToEnum() noexcept;
-    
-    /**
-     * @brief Find point ID by pointer.
-     */
-    [[nodiscard]] std::optional<ID> findPointID(const Point2D* ptr) const noexcept;
+
+    std::vector<std::unique_ptr<Point2D>> m_pointSlots;
+    std::vector<std::size_t>              m_pointFree;
+    std::vector<std::unique_ptr<Line2D>> m_lineSlots;
+    std::vector<std::size_t>              m_lineFree;
+    std::vector<std::unique_ptr<Circle2D>> m_circleSlots;
+    std::vector<std::size_t>              m_circleFree;
+    std::vector<std::unique_ptr<Arc2D>> m_arcSlots;
+    std::vector<std::size_t>              m_arcFree;
+
+    std::unordered_map<ID, FigureEntry> m_index;
+    IDGenerator                         m_idGen;
+    GeometryDependencyIndex             m_deps;
+
+    std::vector<FigureRef<Point2D>>  m_pointsWithIds;
+    std::vector<FigureRef<Line2D>>   m_linesWithIds;
+    std::vector<FigureRef<Circle2D>> m_circlesWithIds;
+    std::vector<FigureRef<Arc2D>>    m_arcsWithIds;
+
+    std::unordered_map<ID, std::size_t> m_pointWithIdPos;
+    std::unordered_map<ID, std::size_t> m_lineWithIdPos;
+    std::unordered_map<ID, std::size_t> m_circleWithIdPos;
+    std::unordered_map<ID, std::size_t> m_arcWithIdPos;
 };
 
+/** @brief Compile-time FigureType for template get(). */
 template <SupportedFigure T>
 constexpr FigureType GeometryStorage::typeToEnum() noexcept {
     if constexpr (std::same_as<T, Point2D>)  return FigureType::ET_POINT2D;
@@ -455,23 +348,67 @@ constexpr FigureType GeometryStorage::typeToEnum() noexcept {
     if constexpr (std::same_as<T, Arc2D>)    return FigureType::ET_ARC;
 }
 
+/** @brief Non-const get(); see class GeometryStorage::get. */
 template <SupportedFigure T>
-T* GeometryStorage::get(ID id) const {
+T* GeometryStorage::get(ID id) noexcept {
     auto it = m_index.find(id);
-    if (it == m_index.end()) {
-        throw std::runtime_error("Object with given ID not found");
+    if (it == m_index.end() || it->second.type != typeToEnum<T>()) {
+        return nullptr;
     }
-    
-    const FigureEntry& entry = it->second;
-    if (entry.type != typeToEnum<T>()) {
-        throw std::runtime_error("Requested type does not match actual type");
+    const std::uint32_t s = it->second.slot;
+    if constexpr (std::same_as<T, Point2D>) {
+        return m_pointSlots[s].get();
+    } else if constexpr (std::same_as<T, Line2D>) {
+        return m_lineSlots[s].get();
+    } else if constexpr (std::same_as<T, Circle2D>) {
+        return m_circleSlots[s].get();
+    } else {
+        return m_arcSlots[s].get();
     }
-    
-    return static_cast<T*>(entry.ptr);
 }
 
+/** @brief Const get(); see class GeometryStorage::get. */
+template <SupportedFigure T>
+const T* GeometryStorage::get(ID id) const noexcept {
+    auto it = m_index.find(id);
+    if (it == m_index.end() || it->second.type != typeToEnum<T>()) {
+        return nullptr;
+    }
+    const std::uint32_t s = it->second.slot;
+    if constexpr (std::same_as<T, Point2D>) {
+        return m_pointSlots[s].get();
+    } else if constexpr (std::same_as<T, Line2D>) {
+        return m_lineSlots[s].get();
+    } else if constexpr (std::same_as<T, Circle2D>) {
+        return m_circleSlots[s].get();
+    } else {
+        return m_arcSlots[s].get();
+    }
+}
+
+/**
+ * @brief Erase-by-swap in the dense FigureRef cache; updates secondary position map.
+ */
+template <typename T>
+void GeometryStorage::eraseCachedById(
+    ID id,
+    std::vector<FigureRef<T>>& cache,
+    std::unordered_map<ID, std::size_t>& posMap
+) noexcept {
+    auto it = posMap.find(id);
+    if (it == posMap.end()) {
+        return;
+    }
+    const std::size_t idx = it->second;
+    const std::size_t lastIdx = cache.size() - 1;
+    if (idx != lastIdx) {
+        cache[idx] = cache[lastIdx];
+        posMap[cache[idx].id] = idx;
+    }
+    cache.pop_back();
+    posMap.erase(it);
+}
 
 } // namespace OurPaintDCM::Figures
 
-#endif // OURPAINTDCM_HEADERS_FIGURES_GEOMETRYSTORAGE_H
-
+#endif

--- a/headers/figures/GeometryStorage.h
+++ b/headers/figures/GeometryStorage.h
@@ -365,6 +365,30 @@ public:
      */
     [[nodiscard]] ObjectGraph buildObjectSubgraph(ID id) const;
 
+    /**
+     * @brief Get all active points with their IDs.
+     * @return Vector of pairs {ID, const Point2D*} for all active points.
+     */
+    [[nodiscard]] std::vector<std::pair<ID, const Point2D*>> allPointsWithID() const;
+
+    /**
+     * @brief Get all active lines with their IDs.
+     * @return Vector of pairs {ID, const Line2D*} for all active lines.
+     */
+    [[nodiscard]] std::vector<std::pair<ID, const Line2D*>> allLinesWithID() const;
+
+    /**
+     * @brief Get all active circles with their IDs.
+     * @return Vector of pairs {ID, const Circle2D*} for all active circles.
+     */
+    [[nodiscard]] std::vector<std::pair<ID, const Circle2D*>> allCirclesWithID() const;
+
+    /**
+     * @brief Get all active arcs with their IDs.
+     * @return Vector of pairs {ID, const Arc2D*} for all active arcs.
+     */
+    [[nodiscard]] std::vector<std::pair<ID, const Arc2D*>> allArcsWithID() const;
+
 private:
     /**
      * @brief Storage for each object type.

--- a/scripts/run_valgrind_all.sh
+++ b/scripts/run_valgrind_all.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR_NAME="${1:-build}"
+TEST_DIR="$ROOT_DIR/$BUILD_DIR_NAME/tests"
+
+if [[ ! -d "$TEST_DIR" ]]; then
+  echo "Test directory not found: $TEST_DIR"
+  echo "Build first: cmake -S . -B $BUILD_DIR_NAME && cmake --build $BUILD_DIR_NAME"
+  exit 2
+fi
+
+fail=0
+for t in "$TEST_DIR"/*GTEST; do
+  name="$(basename "$t")"
+  log="/tmp/vg_${name}.log"
+  echo "=== $name ==="
+
+  if valgrind \
+    --leak-check=full \
+    --show-leak-kinds=definite,indirect,possible \
+    --errors-for-leak-kinds=definite,indirect,possible \
+    --error-exitcode=42 \
+    "$t" >"$log" 2>&1; then
+    echo "OK"
+  else
+    rc=$?
+    echo "FAIL rc=$rc"
+    fail=1
+  fi
+
+  awk '/ERROR SUMMARY|definitely lost|indirectly lost|possibly lost/' "$log" || true
+done
+
+exit "$fail"

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -305,7 +305,7 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
     for (const auto& [id, desc] : _figureRecords) {
         auto fullDesc = getFigure(id);
         if (fullDesc.has_value()) {
-            result.push_back(fullDesc.value());
+            result.push_back(std::move(*fullDesc));
         }
     }
     return result;

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -312,16 +312,20 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
-    const auto& pointsWithID = _storage.pointsWithIds();
+    const auto& points = _storage.pointsWithIds();
     std::vector<Utils::FigureDescriptor> result;
-    result.reserve(pointsWithID.size());
-    for (const auto& ref : pointsWithID) {
+    result.reserve(points.size());
+    for (const auto& ref : points) {
+        if (ref.ptr == nullptr) {
+            continue;
+        }
         Utils::FigureDescriptor desc;
         desc.id = ref.id;
         desc.type = Utils::FigureType::ET_POINT2D;
+        desc.coords = {ref.ptr->x(), ref.ptr->y()};
         desc.x = ref.ptr->x();
         desc.y = ref.ptr->y();
-        result.push_back(desc);
+        result.push_back(std::move(desc));
     }
     return result;
 }

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -457,8 +457,8 @@ bool DCMManager::hasRequirement(Utils::ID reqId) const noexcept {
 std::vector<Utils::RequirementDescriptor> DCMManager::getAllRequirements() const {
     std::vector<Utils::RequirementDescriptor> result;
     result.reserve(_requirementRecords.size());
-    for (const auto& [id, desc] : _requirementRecords) {
-        result.push_back(desc);
+    for (const auto& entry : _requirementRecords) {
+        result.push_back(entry.second);
     }
     return result;
 }

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -139,6 +139,8 @@ Utils::ID DCMManager::addFigure(const Utils::FigureDescriptor& descriptor) {
             }
             break;
         }
+        default:
+            throw std::invalid_argument("Unsupported figure type for addFigure");
     }
 
     storedDesc.id = figureId;

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -261,6 +261,64 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
     return result;
 }
 
+std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
+    const auto pointsWithID = _storage.allPointsWithID();
+    std::vector<Utils::FigureDescriptor> result;
+    result.reserve(pointsWithID.size());
+    for (const auto& [id, ptr] : pointsWithID) {
+        result.push_back({
+            .id = id,
+            .type = Utils::FigureType::ET_POINT2D,
+            .center = {ptr->x(), ptr->y()}
+        });
+    }
+    return result;
+}
+
+std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
+    const auto linesWithID = _storage.allLinesWithID();
+    std::vector<Utils::FigureDescriptor> result;
+    result.reserve(linesWithID.size());
+    for (const auto& [id, ptr] : linesWithID) {
+        result.push_back({
+            .id = id,
+            .type = Utils::FigureType::ET_LINE,
+            .points = {{ptr->p1->x(), ptr->p1->y()}, {ptr->p2->x(), ptr->p2->y()}}
+        });
+    }
+    return result;
+}
+
+std::vector<Utils::FigureDescriptor> DCMManager::getAllCircles() const {
+    const auto circlesWithID = _storage.allCirclesWithID();
+    std::vector<Utils::FigureDescriptor> result;
+    result.reserve(circlesWithID.size());
+    for (const auto& [id, ptr] : circlesWithID) {
+        result.push_back({
+            .id = id,
+            .type = Utils::FigureType::ET_CIRCLE,
+            .center = {ptr->center->x(), ptr->center->y()},
+            .radius = ptr->radius
+        });
+    }
+    return result;
+}
+
+std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
+    const auto arcsWithID = _storage.allArcsWithID();
+    std::vector<Utils::FigureDescriptor> result;
+    result.reserve(arcsWithID.size());
+    for (const auto& [id, ptr] : arcsWithID) {
+        result.push_back({
+            .id = id,
+            .type = Utils::FigureType::ET_ARC,
+            .points = {{ptr->p1->x(), ptr->p1->y()}, {ptr->p2->x(), ptr->p2->y()}},
+            .center = {ptr->p_center->x(), ptr->p_center->y()}
+        });
+    }
+    return result;
+}
+
 Utils::ID DCMManager::addRequirement(const Utils::RequirementDescriptor& descriptor) {
     descriptor.validate();
 

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -331,65 +331,74 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
-    const auto& linesWithID = _storage.linesWithIds();
+    const auto& lines = _storage.linesWithIds();
     std::vector<Utils::FigureDescriptor> result;
-    result.reserve(linesWithID.size());
-    for (const auto& ref : linesWithID) {
-        auto rec = _figureRecords.find(ref.id);
-        if (rec == _figureRecords.end()) continue;
-        
-        auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
-        auto* p2 = _storage.get<Figures::Point2D>(rec->second.pointIds[1]);
-        
+    result.reserve(lines.size());
+    for (const auto& ref : lines) {
+        const auto rec = _figureRecords.find(ref.id);
+        if (rec == _figureRecords.end() || rec->second.pointIds.size() < 2 || ref.ptr == nullptr) {
+            continue;
+        }
+        const Figures::Point2D* p1 = ref.ptr->p1;
+        const Figures::Point2D* p2 = ref.ptr->p2;
+        if (p1 == nullptr || p2 == nullptr) {
+            continue;
+        }
         Utils::FigureDescriptor desc;
         desc.id = ref.id;
         desc.type = Utils::FigureType::ET_LINE;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {p1->x(), p1->y(), p2->x(), p2->y()};
-        result.push_back(desc);
+        result.push_back(std::move(desc));
     }
     return result;
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllCircles() const {
-    const auto& circlesWithID = _storage.circlesWithIds();
+    const auto& circles = _storage.circlesWithIds();
     std::vector<Utils::FigureDescriptor> result;
-    result.reserve(circlesWithID.size());
-    for (const auto& ref : circlesWithID) {
-        auto rec = _figureRecords.find(ref.id);
-        if (rec == _figureRecords.end()) continue;
-        
-        auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
-        
+    result.reserve(circles.size());
+    for (const auto& ref : circles) {
+        const auto rec = _figureRecords.find(ref.id);
+        if (rec == _figureRecords.end() || rec->second.pointIds.empty() || ref.ptr == nullptr) {
+            continue;
+        }
+        const Figures::Point2D* center = ref.ptr->center;
+        if (center == nullptr) {
+            continue;
+        }
         Utils::FigureDescriptor desc;
         desc.id = ref.id;
         desc.type = Utils::FigureType::ET_CIRCLE;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {center->x(), center->y()};
         desc.radius = ref.ptr->radius;
-        result.push_back(desc);
+        result.push_back(std::move(desc));
     }
     return result;
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
-    const auto& arcsWithID = _storage.arcsWithIds();
+    const auto& arcs = _storage.arcsWithIds();
     std::vector<Utils::FigureDescriptor> result;
-    result.reserve(arcsWithID.size());
-    for (const auto& ref : arcsWithID) {
-        auto rec = _figureRecords.find(ref.id);
-        if (rec == _figureRecords.end()) continue;
-        
-        auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
-        auto* p2 = _storage.get<Figures::Point2D>(rec->second.pointIds[1]);
-        auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[2]);
-        
+    result.reserve(arcs.size());
+    for (const auto& ref : arcs) {
+        const auto rec = _figureRecords.find(ref.id);
+        if (rec == _figureRecords.end() || rec->second.pointIds.size() < 3 || ref.ptr == nullptr) {
+            continue;
+        }
+        const Figures::Point2D* p1 = ref.ptr->p1;
+        const Figures::Point2D* p2 = ref.ptr->p2;
+        const Figures::Point2D* center = ref.ptr->p_center;
+        if (p1 == nullptr || p2 == nullptr || center == nullptr) {
+            continue;
+        }
         Utils::FigureDescriptor desc;
         desc.id = ref.id;
         desc.type = Utils::FigureType::ET_ARC;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {p1->x(), p1->y(), p2->x(), p2->y(), center->x(), center->y()};
-        result.push_back(desc);
+        result.push_back(std::move(desc));
     }
     return result;
 }

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -298,7 +298,7 @@ std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId)
 }
 
 bool DCMManager::hasFigure(Utils::ID figureId) const noexcept {
-    return _figureRecords.count(figureId) > 0 && _storage.contains(figureId);
+    return _figureRecords.contains(figureId) && _storage.contains(figureId);
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
@@ -440,7 +440,7 @@ std::optional<Utils::RequirementDescriptor> DCMManager::getRequirement(Utils::ID
 }
 
 bool DCMManager::hasRequirement(Utils::ID reqId) const noexcept {
-    return _requirementRecords.count(reqId) > 0;
+    return _requirementRecords.contains(reqId);
 }
 
 std::vector<Utils::RequirementDescriptor> DCMManager::getAllRequirements() const {
@@ -481,7 +481,7 @@ std::vector<Utils::ID> DCMManager::getRequirementsInComponent(ComponentID compon
 
     for (const auto& [reqId, desc] : _requirementRecords) {
         for (const auto& objId : desc.objectIds) {
-            if (compFigures.count(objId) > 0) {
+            if (compFigures.contains(objId)) {
                 result.push_back(reqId);
                 break;
             }

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -266,10 +266,12 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(pointsWithID.size());
     for (const auto& [id, ptr] : pointsWithID) {
-        auto desc = getFigure(id);
-        if (desc.has_value()) {
-            result.push_back(desc.value());
-        }
+        Utils::FigureDescriptor desc;
+        desc.id = id;
+        desc.type = Utils::FigureType::ET_POINT2D;
+        desc.x = ptr->x();
+        desc.y = ptr->y();
+        result.push_back(desc);
     }
     return result;
 }
@@ -279,10 +281,18 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(linesWithID.size());
     for (const auto& [id, ptr] : linesWithID) {
-        auto desc = getFigure(id);
-        if (desc.has_value()) {
-            result.push_back(desc.value());
-        }
+        auto rec = _figureRecords.find(id);
+        if (rec == _figureRecords.end()) continue;
+        
+        auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
+        auto* p2 = _storage.get<Figures::Point2D>(rec->second.pointIds[1]);
+        
+        Utils::FigureDescriptor desc;
+        desc.id = id;
+        desc.type = Utils::FigureType::ET_LINE;
+        desc.pointIds = rec->second.pointIds;
+        desc.coords = {p1->x(), p1->y(), p2->x(), p2->y()};
+        result.push_back(desc);
     }
     return result;
 }
@@ -292,10 +302,18 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllCircles() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(circlesWithID.size());
     for (const auto& [id, ptr] : circlesWithID) {
-        auto desc = getFigure(id);
-        if (desc.has_value()) {
-            result.push_back(desc.value());
-        }
+        auto rec = _figureRecords.find(id);
+        if (rec == _figureRecords.end()) continue;
+        
+        auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
+        
+        Utils::FigureDescriptor desc;
+        desc.id = id;
+        desc.type = Utils::FigureType::ET_CIRCLE;
+        desc.pointIds = rec->second.pointIds;
+        desc.coords = {center->x(), center->y()};
+        desc.radius = ptr->radius;
+        result.push_back(desc);
     }
     return result;
 }
@@ -305,10 +323,19 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(arcsWithID.size());
     for (const auto& [id, ptr] : arcsWithID) {
-        auto desc = getFigure(id);
-        if (desc.has_value()) {
-            result.push_back(desc.value());
-        }
+        auto rec = _figureRecords.find(id);
+        if (rec == _figureRecords.end()) continue;
+        
+        auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
+        auto* p2 = _storage.get<Figures::Point2D>(rec->second.pointIds[1]);
+        auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[2]);
+        
+        Utils::FigureDescriptor desc;
+        desc.id = id;
+        desc.type = Utils::FigureType::ET_ARC;
+        desc.pointIds = rec->second.pointIds;
+        desc.coords = {p1->x(), p1->y(), p2->x(), p2->y(), center->x(), center->y()};
+        result.push_back(desc);
     }
     return result;
 }

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -1,8 +1,5 @@
 #include "DCMManager.h"
-#include <algorithm>
 #include <stdexcept>
-
-
 
 namespace {
 
@@ -541,7 +538,6 @@ void DCMManager::clear() {
 void DCMManager::setSolveMode(Utils::SolveMode mode) noexcept {
     _solveMode = mode;
 }
-
 
 Utils::SolveMode DCMManager::getSolveMode() const noexcept {
     return _solveMode;

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -256,24 +256,22 @@ std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId)
             if (desc.pointIds.size() < 2) {
                 return std::nullopt;
             }
-            auto* p1 = _storage.get<Figures::Point2D>(desc.pointIds[0]);
-            auto* p2 = _storage.get<Figures::Point2D>(desc.pointIds[1]);
-            if (!p1 || !p2) {
+            const auto* line = _storage.get<Figures::Line2D>(figureId);
+            if (line == nullptr || line->p1 == nullptr || line->p2 == nullptr) {
                 return std::nullopt;
             }
-            desc.coords = {p1->x(), p1->y(), p2->x(), p2->y()};
+            desc.coords = {line->p1->x(), line->p1->y(), line->p2->x(), line->p2->y()};
             break;
         }
         case Utils::FigureType::ET_CIRCLE: {
             if (desc.pointIds.empty()) {
                 return std::nullopt;
             }
-            auto* center = _storage.get<Figures::Point2D>(desc.pointIds[0]);
-            auto* circle = _storage.get<Figures::Circle2D>(figureId);
-            if (!center || !circle) {
+            const auto* circle = _storage.get<Figures::Circle2D>(figureId);
+            if (circle == nullptr || circle->center == nullptr) {
                 return std::nullopt;
             }
-            desc.coords = {center->x(), center->y()};
+            desc.coords = {circle->center->x(), circle->center->y()};
             desc.radius = circle->radius;
             break;
         }
@@ -281,17 +279,17 @@ std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId)
             if (desc.pointIds.size() < 3) {
                 return std::nullopt;
             }
-            auto* p1 = _storage.get<Figures::Point2D>(desc.pointIds[0]);
-            auto* p2 = _storage.get<Figures::Point2D>(desc.pointIds[1]);
-            auto* center = _storage.get<Figures::Point2D>(desc.pointIds[2]);
-            if (!p1 || !p2 || !center) {
+            const auto* arc = _storage.get<Figures::Arc2D>(figureId);
+            if (arc == nullptr || arc->p1 == nullptr || arc->p2 == nullptr || arc->p_center == nullptr) {
                 return std::nullopt;
             }
-            desc.coords = {p1->x(), p1->y(), p2->x(), p2->y(), center->x(), center->y()};
+            desc.coords = {
+                arc->p1->x(), arc->p1->y(), arc->p2->x(), arc->p2->y(),
+                arc->p_center->x(), arc->p_center->y()};
             break;
         }
         default:
-            break;
+            return std::nullopt;
     }
 
     return desc;

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -609,16 +609,22 @@ bool DCMManager::solve(std::optional<ComponentID> componentId) {
         optimizer.setTask(&task);
         optimizer.optimize();
         converged = optimizer.isConverged();
+        // LSMTask::~LSMTask deletes residual functions in mathFuncs (non-VARIABLE); do not delete here.
     } else {
         LSMFORLMTask task(mathFuncs, mathVars);
         LMSparse solver;
         solver.setTask(&task);
         solver.optimize();
         converged = solver.isConverged();
-        for (auto* f : mathFuncs) delete f;
+        for (auto* f : mathFuncs) {
+            delete f;
+        }
+        // LSMFORLMTask does not own m_functions; only c_function and Jacobian entries are freed in ~LSMFORLMTask.
     }
 
-    for (auto* v : mathVars) delete v;
+    for (auto* v : mathVars) {
+        delete v;
+    }
     return converged;
 }
 
@@ -672,13 +678,13 @@ void DCMManager::rebuildComponents() {
     _nextComponentId = 0;
     _activeComponentCount = 0;
 
-    for (const auto& [id, desc] : _figureRecords) {
-        ComponentID compId = createNewComponent();
-        addFigureToComponent(id, compId);
+    for (const auto& entry : _figureRecords) {
+        const ComponentID compId = createNewComponent();
+        addFigureToComponent(entry.first, compId);
     }
 
-    for (const auto& [id, desc] : _requirementRecords) {
-        mergeComponents(desc.objectIds);
+    for (const auto& entry : _requirementRecords) {
+        mergeComponents(entry.second.objectIds);
     }
 }
 

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -69,63 +69,75 @@ Utils::ID DCMManager::addFigure(const Utils::FigureDescriptor& descriptor) {
         case Utils::FigureType::ET_POINT2D: {
             const double px = descriptor.coords.size() == 2 ? descriptor.coords[0] : descriptor.x.value();
             const double py = descriptor.coords.size() == 2 ? descriptor.coords[1] : descriptor.y.value();
-            auto [id, ptr] = _storage.createPoint(px, py);
-            figureId = id;
+            figureId = _storage.createPoint(px, py);
             break;
         }
         case Utils::FigureType::ET_LINE: {
             if (descriptor.coords.size() == 4) {
-                auto [p1Id, p1Ptr] = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
-                auto [p2Id, p2Ptr] = _storage.createPoint(descriptor.coords[2], descriptor.coords[3]);
+                const Utils::ID p1Id = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
+                const Utils::ID p2Id = _storage.createPoint(descriptor.coords[2], descriptor.coords[3]);
                 registerPoint(p1Id, descriptor.coords[0], descriptor.coords[1]);
                 registerPoint(p2Id, descriptor.coords[2], descriptor.coords[3]);
-                auto [id, ptr] = _storage.createLine(p1Ptr, p2Ptr);
-                figureId = id;
+                auto lineOpt = _storage.createLine(p1Id, p2Id);
+                if (!lineOpt) {
+                    throw std::runtime_error("Line creation failed");
+                }
+                figureId = *lineOpt;
                 relatedFigures = {p1Id, p2Id};
                 storedDesc.pointIds = relatedFigures;
             } else {
-                auto* p1 = _storage.get<Figures::Point2D>(descriptor.pointIds[0]);
-                auto* p2 = _storage.get<Figures::Point2D>(descriptor.pointIds[1]);
-                auto [id, ptr] = _storage.createLine(p1, p2);
-                figureId = id;
+                auto lineOpt = _storage.createLine(descriptor.pointIds[0], descriptor.pointIds[1]);
+                if (!lineOpt) {
+                    throw std::runtime_error("Line creation failed");
+                }
+                figureId = *lineOpt;
                 relatedFigures = descriptor.pointIds;
             }
             break;
         }
         case Utils::FigureType::ET_CIRCLE: {
             if (descriptor.coords.size() == 2) {
-                auto [centerId, cPtr] = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
+                const Utils::ID centerId = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
                 registerPoint(centerId, descriptor.coords[0], descriptor.coords[1]);
-                auto [id, ptr] = _storage.createCircle(cPtr, descriptor.radius.value());
-                figureId = id;
+                auto circOpt = _storage.createCircle(centerId, descriptor.radius.value());
+                if (!circOpt) {
+                    throw std::runtime_error("Circle creation failed");
+                }
+                figureId = *circOpt;
                 relatedFigures = {centerId};
                 storedDesc.pointIds = relatedFigures;
             } else {
-                auto* center = _storage.get<Figures::Point2D>(descriptor.pointIds[0]);
-                auto [id, ptr] = _storage.createCircle(center, descriptor.radius.value());
-                figureId = id;
+                auto circOpt = _storage.createCircle(descriptor.pointIds[0], descriptor.radius.value());
+                if (!circOpt) {
+                    throw std::runtime_error("Circle creation failed");
+                }
+                figureId = *circOpt;
                 relatedFigures = descriptor.pointIds;
             }
             break;
         }
         case Utils::FigureType::ET_ARC: {
             if (descriptor.coords.size() == 6) {
-                auto [p1Id, p1Ptr] = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
-                auto [p2Id, p2Ptr] = _storage.createPoint(descriptor.coords[2], descriptor.coords[3]);
-                auto [centerId, cPtr] = _storage.createPoint(descriptor.coords[4], descriptor.coords[5]);
+                const Utils::ID p1Id = _storage.createPoint(descriptor.coords[0], descriptor.coords[1]);
+                const Utils::ID p2Id = _storage.createPoint(descriptor.coords[2], descriptor.coords[3]);
+                const Utils::ID centerId = _storage.createPoint(descriptor.coords[4], descriptor.coords[5]);
                 registerPoint(p1Id, descriptor.coords[0], descriptor.coords[1]);
                 registerPoint(p2Id, descriptor.coords[2], descriptor.coords[3]);
                 registerPoint(centerId, descriptor.coords[4], descriptor.coords[5]);
-                auto [id, ptr] = _storage.createArc(p1Ptr, p2Ptr, cPtr);
-                figureId = id;
+                auto arcOpt = _storage.createArc(p1Id, p2Id, centerId);
+                if (!arcOpt) {
+                    throw std::runtime_error("Arc creation failed");
+                }
+                figureId = *arcOpt;
                 relatedFigures = {p1Id, p2Id, centerId};
                 storedDesc.pointIds = relatedFigures;
             } else {
-                auto* p1 = _storage.get<Figures::Point2D>(descriptor.pointIds[0]);
-                auto* p2 = _storage.get<Figures::Point2D>(descriptor.pointIds[1]);
-                auto* center = _storage.get<Figures::Point2D>(descriptor.pointIds[2]);
-                auto [id, ptr] = _storage.createArc(p1, p2, center);
-                figureId = id;
+                auto arcOpt = _storage.createArc(
+                    descriptor.pointIds[0], descriptor.pointIds[1], descriptor.pointIds[2]);
+                if (!arcOpt) {
+                    throw std::runtime_error("Arc creation failed");
+                }
+                figureId = *arcOpt;
                 relatedFigures = descriptor.pointIds;
             }
             break;
@@ -158,10 +170,30 @@ void DCMManager::removeFigure(Utils::ID figureId, bool forceCascade) {
         }
     }
 
-    _figureRecords.erase(figureId);
+    std::vector<Utils::ID> cascadedFigures;
+    if (forceCascade) {
+        const auto ty = _storage.getType(figureId);
+        if (ty.has_value() && *ty == Utils::FigureType::ET_POINT2D) {
+            cascadedFigures = _storage.getDependents(figureId);
+        }
+    }
 
+    const auto removed = _storage.remove(figureId, forceCascade);
+    if (removed == Figures::RemoveResult::NotFound) {
+        throw std::runtime_error("Figure not found");
+    }
+    if (removed == Figures::RemoveResult::BlockedByDependents) {
+        throw std::runtime_error("Dependencies exist");
+    }
+
+    for (const auto& id : cascadedFigures) {
+        _figureRecords.erase(id);
+        removeFigureFromComponent(id);
+    }
+    _figureRecords.erase(figureId);
     removeFigureFromComponent(figureId);
-    _storage.remove(figureId, forceCascade);
+
+    pruneRequirementsWithMissingObjects();
     splitComponentsAfterRemoval();
 }
 
@@ -204,7 +236,7 @@ void DCMManager::updateCircle(const Utils::CircleUpdateDescriptor& descriptor) {
 
 std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId) const {
     auto it = _figureRecords.find(figureId);
-    if (it == _figureRecords.end()) {
+    if (it == _figureRecords.end() || !_storage.contains(figureId)) {
         return std::nullopt;
     }
 
@@ -213,28 +245,49 @@ std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId)
     switch (desc.type) {
         case Utils::FigureType::ET_POINT2D: {
             auto* point = _storage.get<Figures::Point2D>(figureId);
+            if (!point) {
+                return std::nullopt;
+            }
             desc.coords = {point->x(), point->y()};
             desc.x = point->x();
             desc.y = point->y();
             break;
         }
         case Utils::FigureType::ET_LINE: {
+            if (desc.pointIds.size() < 2) {
+                return std::nullopt;
+            }
             auto* p1 = _storage.get<Figures::Point2D>(desc.pointIds[0]);
             auto* p2 = _storage.get<Figures::Point2D>(desc.pointIds[1]);
+            if (!p1 || !p2) {
+                return std::nullopt;
+            }
             desc.coords = {p1->x(), p1->y(), p2->x(), p2->y()};
             break;
         }
         case Utils::FigureType::ET_CIRCLE: {
+            if (desc.pointIds.empty()) {
+                return std::nullopt;
+            }
             auto* center = _storage.get<Figures::Point2D>(desc.pointIds[0]);
             auto* circle = _storage.get<Figures::Circle2D>(figureId);
+            if (!center || !circle) {
+                return std::nullopt;
+            }
             desc.coords = {center->x(), center->y()};
             desc.radius = circle->radius;
             break;
         }
         case Utils::FigureType::ET_ARC: {
+            if (desc.pointIds.size() < 3) {
+                return std::nullopt;
+            }
             auto* p1 = _storage.get<Figures::Point2D>(desc.pointIds[0]);
             auto* p2 = _storage.get<Figures::Point2D>(desc.pointIds[1]);
             auto* center = _storage.get<Figures::Point2D>(desc.pointIds[2]);
+            if (!p1 || !p2 || !center) {
+                return std::nullopt;
+            }
             desc.coords = {p1->x(), p1->y(), p2->x(), p2->y(), center->x(), center->y()};
             break;
         }
@@ -246,7 +299,7 @@ std::optional<Utils::FigureDescriptor> DCMManager::getFigure(Utils::ID figureId)
 }
 
 bool DCMManager::hasFigure(Utils::ID figureId) const noexcept {
-    return _figureRecords.count(figureId) > 0;
+    return _figureRecords.count(figureId) > 0 && _storage.contains(figureId);
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
@@ -262,33 +315,33 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllFigures() const {
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
-    const auto pointsWithID = _storage.allPointsWithID();
+    const auto& pointsWithID = _storage.pointsWithIds();
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(pointsWithID.size());
-    for (const auto& [id, ptr] : pointsWithID) {
+    for (const auto& ref : pointsWithID) {
         Utils::FigureDescriptor desc;
-        desc.id = id;
+        desc.id = ref.id;
         desc.type = Utils::FigureType::ET_POINT2D;
-        desc.x = ptr->x();
-        desc.y = ptr->y();
+        desc.x = ref.ptr->x();
+        desc.y = ref.ptr->y();
         result.push_back(desc);
     }
     return result;
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
-    const auto linesWithID = _storage.allLinesWithID();
+    const auto& linesWithID = _storage.linesWithIds();
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(linesWithID.size());
-    for (const auto& [id, ptr] : linesWithID) {
-        auto rec = _figureRecords.find(id);
+    for (const auto& ref : linesWithID) {
+        auto rec = _figureRecords.find(ref.id);
         if (rec == _figureRecords.end()) continue;
         
         auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
         auto* p2 = _storage.get<Figures::Point2D>(rec->second.pointIds[1]);
         
         Utils::FigureDescriptor desc;
-        desc.id = id;
+        desc.id = ref.id;
         desc.type = Utils::FigureType::ET_LINE;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {p1->x(), p1->y(), p2->x(), p2->y()};
@@ -298,32 +351,32 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllCircles() const {
-    const auto circlesWithID = _storage.allCirclesWithID();
+    const auto& circlesWithID = _storage.circlesWithIds();
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(circlesWithID.size());
-    for (const auto& [id, ptr] : circlesWithID) {
-        auto rec = _figureRecords.find(id);
+    for (const auto& ref : circlesWithID) {
+        auto rec = _figureRecords.find(ref.id);
         if (rec == _figureRecords.end()) continue;
         
         auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
         
         Utils::FigureDescriptor desc;
-        desc.id = id;
+        desc.id = ref.id;
         desc.type = Utils::FigureType::ET_CIRCLE;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {center->x(), center->y()};
-        desc.radius = ptr->radius;
+        desc.radius = ref.ptr->radius;
         result.push_back(desc);
     }
     return result;
 }
 
 std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
-    const auto arcsWithID = _storage.allArcsWithID();
+    const auto& arcsWithID = _storage.arcsWithIds();
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(arcsWithID.size());
-    for (const auto& [id, ptr] : arcsWithID) {
-        auto rec = _figureRecords.find(id);
+    for (const auto& ref : arcsWithID) {
+        auto rec = _figureRecords.find(ref.id);
         if (rec == _figureRecords.end()) continue;
         
         auto* p1 = _storage.get<Figures::Point2D>(rec->second.pointIds[0]);
@@ -331,7 +384,7 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
         auto* center = _storage.get<Figures::Point2D>(rec->second.pointIds[2]);
         
         Utils::FigureDescriptor desc;
-        desc.id = id;
+        desc.id = ref.id;
         desc.type = Utils::FigureType::ET_ARC;
         desc.pointIds = rec->second.pointIds;
         desc.coords = {p1->x(), p1->y(), p2->x(), p2->y(), center->x(), center->y()};
@@ -467,7 +520,7 @@ System::RequirementSystem& DCMManager::requirementSystem() noexcept {
 }
 
 std::size_t DCMManager::figureCount() const noexcept {
-    return _figureRecords.size();
+    return _storage.size();
 }
 
 std::size_t DCMManager::requirementCount() const noexcept {
@@ -579,6 +632,28 @@ void DCMManager::rebuildRequirementSystem() {
     _reqSystem.clear();
     for (const auto& [id, desc] : _requirementRecords) {
         _reqSystem.addRequirement(desc);
+    }
+}
+
+void DCMManager::pruneRequirementsWithMissingObjects() {
+    bool changed = false;
+    for (auto it = _requirementRecords.begin(); it != _requirementRecords.end();) {
+        bool stale = false;
+        for (const auto& oid : it->second.objectIds) {
+            if (!_storage.contains(oid)) {
+                stale = true;
+                break;
+            }
+        }
+        if (stale) {
+            it = _requirementRecords.erase(it);
+            changed = true;
+        } else {
+            ++it;
+        }
+    }
+    if (changed) {
+        rebuildRequirementSystem();
     }
 }
 

--- a/src/DCMManager.cpp
+++ b/src/DCMManager.cpp
@@ -266,11 +266,10 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllPoints() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(pointsWithID.size());
     for (const auto& [id, ptr] : pointsWithID) {
-        result.push_back({
-            .id = id,
-            .type = Utils::FigureType::ET_POINT2D,
-            .center = {ptr->x(), ptr->y()}
-        });
+        auto desc = getFigure(id);
+        if (desc.has_value()) {
+            result.push_back(desc.value());
+        }
     }
     return result;
 }
@@ -280,11 +279,10 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllLines() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(linesWithID.size());
     for (const auto& [id, ptr] : linesWithID) {
-        result.push_back({
-            .id = id,
-            .type = Utils::FigureType::ET_LINE,
-            .points = {{ptr->p1->x(), ptr->p1->y()}, {ptr->p2->x(), ptr->p2->y()}}
-        });
+        auto desc = getFigure(id);
+        if (desc.has_value()) {
+            result.push_back(desc.value());
+        }
     }
     return result;
 }
@@ -294,12 +292,10 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllCircles() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(circlesWithID.size());
     for (const auto& [id, ptr] : circlesWithID) {
-        result.push_back({
-            .id = id,
-            .type = Utils::FigureType::ET_CIRCLE,
-            .center = {ptr->center->x(), ptr->center->y()},
-            .radius = ptr->radius
-        });
+        auto desc = getFigure(id);
+        if (desc.has_value()) {
+            result.push_back(desc.value());
+        }
     }
     return result;
 }
@@ -309,12 +305,10 @@ std::vector<Utils::FigureDescriptor> DCMManager::getAllArcs() const {
     std::vector<Utils::FigureDescriptor> result;
     result.reserve(arcsWithID.size());
     for (const auto& [id, ptr] : arcsWithID) {
-        result.push_back({
-            .id = id,
-            .type = Utils::FigureType::ET_ARC,
-            .points = {{ptr->p1->x(), ptr->p1->y()}, {ptr->p2->x(), ptr->p2->y()}},
-            .center = {ptr->p_center->x(), ptr->p_center->y()}
-        });
+        auto desc = getFigure(id);
+        if (desc.has_value()) {
+            result.push_back(desc.value());
+        }
     }
     return result;
 }

--- a/src/figures/GeometryDependencyIndex.cpp
+++ b/src/figures/GeometryDependencyIndex.cpp
@@ -1,0 +1,84 @@
+#include "GeometryDependencyIndex.h"
+
+#include <algorithm>
+
+namespace OurPaintDCM::Figures {
+
+const std::vector<Utils::ID> GeometryDependencyIndex::kEmpty{};
+
+void GeometryDependencyIndex::pushUnique(std::vector<Utils::ID>& vec, Utils::ID id) {
+    if (std::find(vec.begin(), vec.end(), id) == vec.end()) {
+        vec.push_back(id);
+    }
+}
+
+void GeometryDependencyIndex::eraseId(std::vector<Utils::ID>& vec, Utils::ID id) {
+    vec.erase(std::remove(vec.begin(), vec.end(), id), vec.end());
+}
+
+void GeometryDependencyIndex::linkLine(Utils::ID lineId, Utils::ID p1, Utils::ID p2) {
+    figureToPoints_[lineId] = {p1, p2};
+    pushUnique(pointToFigures_[p1], lineId);
+    pushUnique(pointToFigures_[p2], lineId);
+}
+
+void GeometryDependencyIndex::linkCircle(Utils::ID circleId, Utils::ID center) {
+    figureToPoints_[circleId] = {center};
+    pushUnique(pointToFigures_[center], circleId);
+}
+
+void GeometryDependencyIndex::linkArc(Utils::ID arcId, Utils::ID p1, Utils::ID p2, Utils::ID center) {
+    figureToPoints_[arcId] = {p1, p2, center};
+    pushUnique(pointToFigures_[p1], arcId);
+    pushUnique(pointToFigures_[p2], arcId);
+    pushUnique(pointToFigures_[center], arcId);
+}
+
+void GeometryDependencyIndex::unlinkFigure(Utils::ID figureId) {
+    auto itFig = figureToPoints_.find(figureId);
+    if (itFig == figureToPoints_.end()) {
+        return;
+    }
+    for (Utils::ID pid : itFig->second) {
+        auto itP = pointToFigures_.find(pid);
+        if (itP != pointToFigures_.end()) {
+            eraseId(itP->second, figureId);
+            if (itP->second.empty()) {
+                pointToFigures_.erase(itP);
+            }
+        }
+    }
+    figureToPoints_.erase(itFig);
+}
+
+std::vector<Utils::ID> GeometryDependencyIndex::dependentsOfPoint(Utils::ID pointId) const {
+    auto it = pointToFigures_.find(pointId);
+    if (it == pointToFigures_.end()) {
+        return {};
+    }
+    return it->second;
+}
+
+const std::vector<Utils::ID>& GeometryDependencyIndex::pointsForFigure(Utils::ID figureId) const noexcept {
+    auto it = figureToPoints_.find(figureId);
+    if (it == figureToPoints_.end()) {
+        return kEmpty;
+    }
+    return it->second;
+}
+
+bool GeometryDependencyIndex::hasDependents(Utils::ID pointId) const noexcept {
+    auto it = pointToFigures_.find(pointId);
+    return it != pointToFigures_.end() && !it->second.empty();
+}
+
+bool GeometryDependencyIndex::emptyFigure(Utils::ID figureId) const noexcept {
+    return figureToPoints_.find(figureId) == figureToPoints_.end();
+}
+
+void GeometryDependencyIndex::clear() noexcept {
+    pointToFigures_.clear();
+    figureToPoints_.clear();
+}
+
+} // namespace OurPaintDCM::Figures

--- a/src/figures/GeometryGraphBuilder.cpp
+++ b/src/figures/GeometryGraphBuilder.cpp
@@ -1,0 +1,78 @@
+#include "GeometryGraphBuilder.h"
+#include "GeometryStorage.h"
+
+namespace OurPaintDCM::Figures {
+
+namespace {
+
+const Utils::ID helperWeight{static_cast<unsigned long long>(-1)};
+
+void addVertexAll(ObjectGraph& g, const GeometryStorage& storage) {
+    for (const auto& r : storage.pointsWithIds()) {
+        g.addVertex(r.id);
+    }
+    for (const auto& r : storage.linesWithIds()) {
+        g.addVertex(r.id);
+    }
+    for (const auto& r : storage.circlesWithIds()) {
+        g.addVertex(r.id);
+    }
+    for (const auto& r : storage.arcsWithIds()) {
+        g.addVertex(r.id);
+    }
+}
+
+void wireFigureEdges(ObjectGraph& g, Utils::ID figId, const GeometryStorage& storage) {
+    for (Utils::ID p : storage.getDependencies(figId)) {
+        g.addVertex(figId);
+        g.addVertex(p);
+        g.addEdge(figId, p, helperWeight);
+    }
+}
+
+} // namespace
+
+ObjectGraph GeometryGraphBuilder::buildObjectGraph(const GeometryStorage& storage) {
+    ObjectGraph graph;
+    addVertexAll(graph, storage);
+    for (const auto& r : storage.linesWithIds()) {
+        wireFigureEdges(graph, r.id, storage);
+    }
+    for (const auto& r : storage.circlesWithIds()) {
+        wireFigureEdges(graph, r.id, storage);
+    }
+    for (const auto& r : storage.arcsWithIds()) {
+        wireFigureEdges(graph, r.id, storage);
+    }
+    return graph;
+}
+
+std::optional<ObjectGraph> GeometryGraphBuilder::buildObjectSubgraph(const GeometryStorage& storage, Utils::ID id) {
+    auto typeOpt = storage.getType(id);
+    if (!typeOpt.has_value()) {
+        return std::nullopt;
+    }
+
+    ObjectGraph graph;
+    graph.addVertex(id);
+
+    if (*typeOpt == FigureType::ET_POINT2D) {
+        for (Utils::ID depFig : storage.getDependents(id)) {
+            graph.addVertex(depFig);
+            graph.addEdge(id, depFig, helperWeight);
+            for (Utils::ID p : storage.getDependencies(depFig)) {
+                graph.addVertex(p);
+                graph.addEdge(depFig, p, helperWeight);
+            }
+        }
+        return graph;
+    }
+
+    for (Utils::ID p : storage.getDependencies(id)) {
+        graph.addVertex(p);
+        graph.addEdge(id, p, helperWeight);
+    }
+    return graph;
+}
+
+} // namespace OurPaintDCM::Figures

--- a/src/figures/GeometryStorage.cpp
+++ b/src/figures/GeometryStorage.cpp
@@ -12,8 +12,8 @@ std::pair<ID, Point2D*> GeometryStorage::createPoint(double x, double y) {
     Point2D* ptr = &m_points.back();
     
     m_index.emplace(id, FigureEntry{FigureType::ET_POINT2D, ptr});
-    
     m_pointToID.emplace(ptr, id);
+    m_pointIDs.push_back(id);
     
     return {id, ptr};
 }
@@ -25,6 +25,7 @@ std::pair<ID, Line2D*> GeometryStorage::createLine(Point2D* p1, Point2D* p2) {
     Line2D* ptr = &m_lines.back();
     
     m_index.emplace(id, FigureEntry{FigureType::ET_LINE, ptr});
+    m_lineIDs.push_back(id);
     
     return {id, ptr};
 }
@@ -36,6 +37,7 @@ std::pair<ID, Circle2D*> GeometryStorage::createCircle(Point2D* center, double r
     Circle2D* ptr = &m_circles.back();
     
     m_index.emplace(id, FigureEntry{FigureType::ET_CIRCLE, ptr});
+    m_circleIDs.push_back(id);
     
     return {id, ptr};
 }
@@ -47,6 +49,7 @@ std::pair<ID, Arc2D*> GeometryStorage::createArc(Point2D* p1, Point2D* p2, Point
     Arc2D* ptr = &m_arcs.back();
     
     m_index.emplace(id, FigureEntry{FigureType::ET_ARC, ptr});
+    m_arcIDs.push_back(id);
     
     return {id, ptr};
 }
@@ -147,11 +150,16 @@ void GeometryStorage::remove(ID id, bool forceCascade) {
         
         const Point2D* ptrPoint = static_cast<const Point2D*>(entry.ptr);
         m_pointToID.erase(ptrPoint);
+        std::erase(m_pointIDs, id);
+    } else if (entry.type == FigureType::ET_LINE) {
+        std::erase(m_lineIDs, id);
+    } else if (entry.type == FigureType::ET_CIRCLE) {
+        std::erase(m_circleIDs, id);
+    } else if (entry.type == FigureType::ET_ARC) {
+        std::erase(m_arcIDs, id);
     }
     
     m_index.erase(it);
-    
-    return;
 }
 
 void GeometryStorage::clear() noexcept {
@@ -161,6 +169,10 @@ void GeometryStorage::clear() noexcept {
     m_arcs.clear();
     m_index.clear();
     m_pointToID.clear();
+    m_pointIDs.clear();
+    m_lineIDs.clear();
+    m_circleIDs.clear();
+    m_arcIDs.clear();
     m_idGen.reset();
 }
 
@@ -205,15 +217,18 @@ std::span<const Arc2D> GeometryStorage::allArcs() const noexcept {
 }
 
 std::vector<ID> GeometryStorage::getIDsByType(FigureType type) const {
-    std::vector<ID> result;
-    
-    for (const auto& [id, entry] : m_index) {
-        if (entry.type == type) {
-            result.push_back(id);
-        }
+    switch (type) {
+        case FigureType::ET_POINT2D:
+            return m_pointIDs;
+        case FigureType::ET_LINE:
+            return m_lineIDs;
+        case FigureType::ET_CIRCLE:
+            return m_circleIDs;
+        case FigureType::ET_ARC:
+            return m_arcIDs;
+        default:
+            return {};
     }
-    
-    return result;
 }
 
 const std::unordered_map<ID, FigureEntry>& GeometryStorage::allEntries() const noexcept {
@@ -225,27 +240,19 @@ std::size_t GeometryStorage::size() const noexcept {
 }
 
 std::size_t GeometryStorage::pointCount() const noexcept {
-    return std::ranges::count_if(m_index, [](const auto& pair) {
-        return pair.second.type == FigureType::ET_POINT2D;
-    });
+    return m_pointIDs.size();
 }
 
 std::size_t GeometryStorage::lineCount() const noexcept {
-    return std::ranges::count_if(m_index, [](const auto& pair) {
-        return pair.second.type == FigureType::ET_LINE;
-    });
+    return m_lineIDs.size();
 }
 
 std::size_t GeometryStorage::circleCount() const noexcept {
-    return std::ranges::count_if(m_index, [](const auto& pair) {
-        return pair.second.type == FigureType::ET_CIRCLE;
-    });
+    return m_circleIDs.size();
 }
 
 std::size_t GeometryStorage::arcCount() const noexcept {
-    return std::ranges::count_if(m_index, [](const auto& pair) {
-        return pair.second.type == FigureType::ET_ARC;
-    });
+    return m_arcIDs.size();
 }
 
 bool GeometryStorage::empty() const noexcept {
@@ -339,18 +346,23 @@ std::vector<ID> GeometryStorage::getDependencies(ID id) const {
 
 std::vector<std::pair<ID, const Point2D*>> GeometryStorage::allPointsWithID() const {
     std::vector<std::pair<ID, const Point2D*>> result;
-    result.reserve(m_pointToID.size());
-    for (const auto& [ptr, id] : m_pointToID) {
-        result.emplace_back(id, ptr);
+    result.reserve(m_pointIDs.size());
+    for (ID id : m_pointIDs) {
+        auto it = m_index.find(id);
+        if (it != m_index.end()) {
+            result.emplace_back(id, static_cast<const Point2D*>(it->second.ptr));
+        }
     }
     return result;
 }
 
 std::vector<std::pair<ID, const Line2D*>> GeometryStorage::allLinesWithID() const {
     std::vector<std::pair<ID, const Line2D*>> result;
-    for (const auto& [id, entry] : m_index) {
-        if (entry.type == FigureType::ET_LINE) {
-            result.emplace_back(id, static_cast<const Line2D*>(entry.ptr));
+    result.reserve(m_lineIDs.size());
+    for (ID id : m_lineIDs) {
+        auto it = m_index.find(id);
+        if (it != m_index.end()) {
+            result.emplace_back(id, static_cast<const Line2D*>(it->second.ptr));
         }
     }
     return result;
@@ -358,9 +370,11 @@ std::vector<std::pair<ID, const Line2D*>> GeometryStorage::allLinesWithID() cons
 
 std::vector<std::pair<ID, const Circle2D*>> GeometryStorage::allCirclesWithID() const {
     std::vector<std::pair<ID, const Circle2D*>> result;
-    for (const auto& [id, entry] : m_index) {
-        if (entry.type == FigureType::ET_CIRCLE) {
-            result.emplace_back(id, static_cast<const Circle2D*>(entry.ptr));
+    result.reserve(m_circleIDs.size());
+    for (ID id : m_circleIDs) {
+        auto it = m_index.find(id);
+        if (it != m_index.end()) {
+            result.emplace_back(id, static_cast<const Circle2D*>(it->second.ptr));
         }
     }
     return result;
@@ -368,9 +382,11 @@ std::vector<std::pair<ID, const Circle2D*>> GeometryStorage::allCirclesWithID() 
 
 std::vector<std::pair<ID, const Arc2D*>> GeometryStorage::allArcsWithID() const {
     std::vector<std::pair<ID, const Arc2D*>> result;
-    for (const auto& [id, entry] : m_index) {
-        if (entry.type == FigureType::ET_ARC) {
-            result.emplace_back(id, static_cast<const Arc2D*>(entry.ptr));
+    result.reserve(m_arcIDs.size());
+    for (ID id : m_arcIDs) {
+        auto it = m_index.find(id);
+        if (it != m_index.end()) {
+            result.emplace_back(id, static_cast<const Arc2D*>(it->second.ptr));
         }
     }
     return result;

--- a/src/figures/GeometryStorage.cpp
+++ b/src/figures/GeometryStorage.cpp
@@ -337,6 +337,45 @@ std::vector<ID> GeometryStorage::getDependencies(ID id) const {
     return result;
 }
 
+std::vector<std::pair<ID, const Point2D*>> GeometryStorage::allPointsWithID() const {
+    std::vector<std::pair<ID, const Point2D*>> result;
+    result.reserve(m_pointToID.size());
+    for (const auto& [ptr, id] : m_pointToID) {
+        result.emplace_back(id, ptr);
+    }
+    return result;
+}
+
+std::vector<std::pair<ID, const Line2D*>> GeometryStorage::allLinesWithID() const {
+    std::vector<std::pair<ID, const Line2D*>> result;
+    for (const auto& [id, entry] : m_index) {
+        if (entry.type == FigureType::ET_LINE) {
+            result.emplace_back(id, static_cast<const Line2D*>(entry.ptr));
+        }
+    }
+    return result;
+}
+
+std::vector<std::pair<ID, const Circle2D*>> GeometryStorage::allCirclesWithID() const {
+    std::vector<std::pair<ID, const Circle2D*>> result;
+    for (const auto& [id, entry] : m_index) {
+        if (entry.type == FigureType::ET_CIRCLE) {
+            result.emplace_back(id, static_cast<const Circle2D*>(entry.ptr));
+        }
+    }
+    return result;
+}
+
+std::vector<std::pair<ID, const Arc2D*>> GeometryStorage::allArcsWithID() const {
+    std::vector<std::pair<ID, const Arc2D*>> result;
+    for (const auto& [id, entry] : m_index) {
+        if (entry.type == FigureType::ET_ARC) {
+            result.emplace_back(id, static_cast<const Arc2D*>(entry.ptr));
+        }
+    }
+    return result;
+}
+
 std::optional<ID> GeometryStorage::findPointID(const Point2D* ptr) const noexcept {
     auto it = m_pointToID.find(ptr);
     if (it != m_pointToID.end()) {

--- a/src/figures/GeometryStorage.cpp
+++ b/src/figures/GeometryStorage.cpp
@@ -1,57 +1,180 @@
 #include "GeometryStorage.h"
+#include "GeometryGraphBuilder.h"
 
 #include <algorithm>
-#include <ranges>
 
 namespace OurPaintDCM::Figures {
 
-std::pair<ID, Point2D*> GeometryStorage::createPoint(double x, double y) {
-    ID id = m_idGen.nextID();
-    
-    m_points.emplace_back(x, y);
-    Point2D* ptr = &m_points.back();
-    
-    m_index.emplace(id, FigureEntry{FigureType::ET_POINT2D, ptr});
-    m_pointToID.emplace(ptr, id);
-    m_pointIDs.push_back(id);
-    
-    return {id, ptr};
+void GeometryStorage::registerPointCache(ID id, const Point2D* ptr) {
+    m_pointWithIdPos.emplace(id, m_pointsWithIds.size());
+    m_pointsWithIds.push_back(FigureRef<Point2D>{id, ptr});
 }
 
-std::pair<ID, Line2D*> GeometryStorage::createLine(Point2D* p1, Point2D* p2) {
-    ID id = m_idGen.nextID();
-    
-    m_lines.emplace_back(p1, p2);
-    Line2D* ptr = &m_lines.back();
-    
-    m_index.emplace(id, FigureEntry{FigureType::ET_LINE, ptr});
-    m_lineIDs.push_back(id);
-    
-    return {id, ptr};
+void GeometryStorage::registerLineCache(ID id, const Line2D* ptr) {
+    m_lineWithIdPos.emplace(id, m_linesWithIds.size());
+    m_linesWithIds.push_back(FigureRef<Line2D>{id, ptr});
 }
 
-std::pair<ID, Circle2D*> GeometryStorage::createCircle(Point2D* center, double radius) {
-    ID id = m_idGen.nextID();
-    
-    m_circles.emplace_back(center, radius);
-    Circle2D* ptr = &m_circles.back();
-    
-    m_index.emplace(id, FigureEntry{FigureType::ET_CIRCLE, ptr});
-    m_circleIDs.push_back(id);
-    
-    return {id, ptr};
+void GeometryStorage::registerCircleCache(ID id, const Circle2D* ptr) {
+    m_circleWithIdPos.emplace(id, m_circlesWithIds.size());
+    m_circlesWithIds.push_back(FigureRef<Circle2D>{id, ptr});
 }
 
-std::pair<ID, Arc2D*> GeometryStorage::createArc(Point2D* p1, Point2D* p2, Point2D* center) {
-    ID id = m_idGen.nextID();
-    
-    m_arcs.emplace_back(p1, p2, center);
-    Arc2D* ptr = &m_arcs.back();
-    
-    m_index.emplace(id, FigureEntry{FigureType::ET_ARC, ptr});
-    m_arcIDs.push_back(id);
-    
-    return {id, ptr};
+void GeometryStorage::registerArcCache(ID id, const Arc2D* ptr) {
+    m_arcWithIdPos.emplace(id, m_arcsWithIds.size());
+    m_arcsWithIds.push_back(FigureRef<Arc2D>{id, ptr});
+}
+
+void GeometryStorage::erasePointCache(ID id) noexcept {
+    eraseCachedById(id, m_pointsWithIds, m_pointWithIdPos);
+}
+
+void GeometryStorage::eraseLineCache(ID id) noexcept {
+    eraseCachedById(id, m_linesWithIds, m_lineWithIdPos);
+}
+
+void GeometryStorage::eraseCircleCache(ID id) noexcept {
+    eraseCachedById(id, m_circlesWithIds, m_circleWithIdPos);
+}
+
+void GeometryStorage::eraseArcCache(ID id) noexcept {
+    eraseCachedById(id, m_arcsWithIds, m_arcWithIdPos);
+}
+
+std::size_t GeometryStorage::allocPoint(double x, double y) {
+    if (!m_pointFree.empty()) {
+        const std::size_t i = m_pointFree.back();
+        m_pointFree.pop_back();
+        m_pointSlots[i] = std::make_unique<Point2D>(x, y);
+        return i;
+    }
+    m_pointSlots.push_back(std::make_unique<Point2D>(x, y));
+    return m_pointSlots.size() - 1;
+}
+
+std::size_t GeometryStorage::allocLine(Point2D* a, Point2D* b) {
+    if (!m_lineFree.empty()) {
+        const std::size_t i = m_lineFree.back();
+        m_lineFree.pop_back();
+        m_lineSlots[i] = std::make_unique<Line2D>(a, b);
+        return i;
+    }
+    m_lineSlots.push_back(std::make_unique<Line2D>(a, b));
+    return m_lineSlots.size() - 1;
+}
+
+std::size_t GeometryStorage::allocCircle(Point2D* c, double r) {
+    if (!m_circleFree.empty()) {
+        const std::size_t i = m_circleFree.back();
+        m_circleFree.pop_back();
+        m_circleSlots[i] = std::make_unique<Circle2D>(c, r);
+        return i;
+    }
+    m_circleSlots.push_back(std::make_unique<Circle2D>(c, r));
+    return m_circleSlots.size() - 1;
+}
+
+std::size_t GeometryStorage::allocArc(Point2D* p1, Point2D* p2, Point2D* c) {
+    if (!m_arcFree.empty()) {
+        const std::size_t i = m_arcFree.back();
+        m_arcFree.pop_back();
+        m_arcSlots[i] = std::make_unique<Arc2D>(p1, p2, c);
+        return i;
+    }
+    m_arcSlots.push_back(std::make_unique<Arc2D>(p1, p2, c));
+    return m_arcSlots.size() - 1;
+}
+
+void GeometryStorage::freePoint(std::size_t slot) {
+    m_pointSlots[slot].reset();
+    m_pointFree.push_back(slot);
+}
+
+void GeometryStorage::freeLine(std::size_t slot) {
+    m_lineSlots[slot].reset();
+    m_lineFree.push_back(slot);
+}
+
+void GeometryStorage::freeCircle(std::size_t slot) {
+    m_circleSlots[slot].reset();
+    m_circleFree.push_back(slot);
+}
+
+void GeometryStorage::freeArc(std::size_t slot) {
+    m_arcSlots[slot].reset();
+    m_arcFree.push_back(slot);
+}
+
+std::optional<ID> GeometryStorage::tryPointId(ID id) const noexcept {
+    auto it = m_index.find(id);
+    if (it == m_index.end() || it->second.type != FigureType::ET_POINT2D) {
+        return std::nullopt;
+    }
+    return id;
+}
+
+ID GeometryStorage::createPoint(double x, double y) {
+    const std::size_t slot = allocPoint(x, y);
+    const ID id = m_idGen.nextID();
+    m_index.emplace(id, FigureEntry{FigureType::ET_POINT2D, static_cast<std::uint32_t>(slot)});
+    registerPointCache(id, m_pointSlots[slot].get());
+    return id;
+}
+
+std::optional<ID> GeometryStorage::createLine(ID p1, ID p2) {
+    auto it1 = m_index.find(p1);
+    auto it2 = m_index.find(p2);
+    if (it1 == m_index.end() || it2 == m_index.end()) {
+        return std::nullopt;
+    }
+    if (it1->second.type != FigureType::ET_POINT2D || it2->second.type != FigureType::ET_POINT2D) {
+        return std::nullopt;
+    }
+    Point2D* a = m_pointSlots[it1->second.slot].get();
+    Point2D* b = m_pointSlots[it2->second.slot].get();
+    const std::size_t slot = allocLine(a, b);
+    const ID id = m_idGen.nextID();
+    m_index.emplace(id, FigureEntry{FigureType::ET_LINE, static_cast<std::uint32_t>(slot)});
+    m_deps.linkLine(id, p1, p2);
+    registerLineCache(id, m_lineSlots[slot].get());
+    return id;
+}
+
+std::optional<ID> GeometryStorage::createCircle(ID center, double radius) {
+    auto it = m_index.find(center);
+    if (it == m_index.end() || it->second.type != FigureType::ET_POINT2D) {
+        return std::nullopt;
+    }
+    Point2D* c = m_pointSlots[it->second.slot].get();
+    const std::size_t slot = allocCircle(c, radius);
+    const ID id = m_idGen.nextID();
+    m_index.emplace(id, FigureEntry{FigureType::ET_CIRCLE, static_cast<std::uint32_t>(slot)});
+    m_deps.linkCircle(id, center);
+    registerCircleCache(id, m_circleSlots[slot].get());
+    return id;
+}
+
+std::optional<ID> GeometryStorage::createArc(ID p1, ID p2, ID center) {
+    auto it1 = m_index.find(p1);
+    auto it2 = m_index.find(p2);
+    auto itc = m_index.find(center);
+    if (it1 == m_index.end() || it2 == m_index.end() || itc == m_index.end()) {
+        return std::nullopt;
+    }
+    if (it1->second.type != FigureType::ET_POINT2D ||
+        it2->second.type != FigureType::ET_POINT2D ||
+        itc->second.type != FigureType::ET_POINT2D) {
+        return std::nullopt;
+    }
+    Point2D* a = m_pointSlots[it1->second.slot].get();
+    Point2D* b = m_pointSlots[it2->second.slot].get();
+    Point2D* c = m_pointSlots[itc->second.slot].get();
+    const std::size_t slot = allocArc(a, b, c);
+    const ID id = m_idGen.nextID();
+    m_index.emplace(id, FigureEntry{FigureType::ET_ARC, static_cast<std::uint32_t>(slot)});
+    m_deps.linkArc(id, p1, p2, center);
+    registerArcCache(id, m_arcSlots[slot].get());
+    return id;
 }
 
 ID GeometryStorage::createFigure(FigureType type, const FigureData& data) {
@@ -61,178 +184,186 @@ ID GeometryStorage::createFigure(FigureType type, const FigureData& data) {
                 throw std::runtime_error("Point data not provided");
             }
             const auto& p = data.points.front();
-            auto result = createPoint(p.x, p.y);
-            return result.first;
+            return createPoint(p.x, p.y);
         }
         case FigureType::ET_LINE: {
             if (data.points.size() < 2) {
                 throw std::runtime_error("Line requires two points");
             }
-            const auto& p1 = data.points[0];
-            const auto& p2 = data.points[1];
-            auto point1 = createPoint(p1.x, p1.y);
-            auto point2 = createPoint(p2.x, p2.y);
-            auto lineResult = createLine(point1.second, point2.second);
-            return lineResult.first;
+            const ID idA = createPoint(data.points[0].x, data.points[0].y);
+            const ID idB = createPoint(data.points[1].x, data.points[1].y);
+            auto lineId = createLine(idA, idB);
+            if (!lineId) {
+                throw std::runtime_error("Line creation failed");
+            }
+            return *lineId;
         }
         case FigureType::ET_CIRCLE: {
-            auto centerPoint = createPoint(data.center.x, data.center.y);
-            auto circleResult = createCircle(centerPoint.second, data.radius);
-            return circleResult.first;
+            const ID c = createPoint(data.center.x, data.center.y);
+            auto circ = createCircle(c, data.radius);
+            if (!circ) {
+                throw std::runtime_error("Circle creation failed");
+            }
+            return *circ;
         }
         case FigureType::ET_ARC: {
             if (data.points.size() < 2) {
                 throw std::runtime_error("Arc requires two endpoints");
             }
-            const auto& p1 = data.points[0];
-            const auto& p2 = data.points[1];
-            auto point1 = createPoint(p1.x, p1.y);
-            auto point2 = createPoint(p2.x, p2.y);
-            auto centerPoint = createPoint(data.center.x, data.center.y);
-            auto arcResult = createArc(point1.second, point2.second, centerPoint.second);
-            return arcResult.first;
+            const ID id1 = createPoint(data.points[0].x, data.points[0].y);
+            const ID id2 = createPoint(data.points[1].x, data.points[1].y);
+            const ID idC = createPoint(data.center.x, data.center.y);
+            auto arcId = createArc(id1, id2, idC);
+            if (!arcId) {
+                throw std::runtime_error("Arc creation failed");
+            }
+            return *arcId;
         }
         default:
             throw std::runtime_error("Unknown figure type");
     }
 }
 
-void* GeometryStorage::getRaw(ID id) const noexcept {
+RemoveResult GeometryStorage::removeFigureOnly(ID id) noexcept {
     auto it = m_index.find(id);
-    return (it != m_index.end()) ? it->second.ptr : nullptr;
+    if (it == m_index.end() || it->second.type == FigureType::ET_POINT2D) {
+        return RemoveResult::NotFound;
+    }
+    const FigureEntry ent = it->second;
+    m_deps.unlinkFigure(id);
+
+    switch (ent.type) {
+        case FigureType::ET_LINE:
+            eraseLineCache(id);
+            m_lineSlots[ent.slot].reset();
+            m_lineFree.push_back(ent.slot);
+            break;
+        case FigureType::ET_CIRCLE:
+            eraseCircleCache(id);
+            m_circleSlots[ent.slot].reset();
+            m_circleFree.push_back(ent.slot);
+            break;
+        case FigureType::ET_ARC:
+            eraseArcCache(id);
+            m_arcSlots[ent.slot].reset();
+            m_arcFree.push_back(ent.slot);
+            break;
+        default:
+            return RemoveResult::NotFound;
+    }
+    m_index.erase(it);
+    return RemoveResult::Ok;
+}
+
+RemoveResult GeometryStorage::remove(ID id, bool forceCascade) noexcept {
+    auto it = m_index.find(id);
+    if (it == m_index.end()) {
+        return RemoveResult::NotFound;
+    }
+
+    if (it->second.type == FigureType::ET_POINT2D) {
+        if (m_deps.hasDependents(id)) {
+            if (!forceCascade) {
+                return RemoveResult::BlockedByDependents;
+            }
+            const std::vector<ID> toRemove = m_deps.dependentsOfPoint(id);
+            for (ID fig : toRemove) {
+                (void)removeFigureOnly(fig);
+            }
+        }
+        auto itPt = m_index.find(id);
+        if (itPt == m_index.end() || itPt->second.type != FigureType::ET_POINT2D) {
+            return RemoveResult::NotFound;
+        }
+        const std::uint32_t slot = itPt->second.slot;
+        erasePointCache(id);
+        freePoint(slot);
+        m_index.erase(itPt);
+        return RemoveResult::Ok;
+    }
+
+    return removeFigureOnly(id);
+}
+
+void GeometryStorage::clear() noexcept {
+    m_pointSlots.clear();
+    m_lineSlots.clear();
+    m_circleSlots.clear();
+    m_arcSlots.clear();
+    m_pointFree.clear();
+    m_lineFree.clear();
+    m_circleFree.clear();
+    m_arcFree.clear();
+    m_index.clear();
+    m_deps.clear();
+    m_pointsWithIds.clear();
+    m_linesWithIds.clear();
+    m_circlesWithIds.clear();
+    m_arcsWithIds.clear();
+    m_pointWithIdPos.clear();
+    m_lineWithIdPos.clear();
+    m_circleWithIdPos.clear();
+    m_arcWithIdPos.clear();
+    m_idGen.reset();
 }
 
 std::optional<FigureType> GeometryStorage::getType(ID id) const noexcept {
     auto it = m_index.find(id);
-    if (it != m_index.end()) {
-        return it->second.type;
+    if (it == m_index.end()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    return it->second.type;
 }
 
 std::optional<FigureEntry> GeometryStorage::getEntry(ID id) const noexcept {
     auto it = m_index.find(id);
-    if (it != m_index.end()) {
-        return it->second;
+    if (it == m_index.end()) {
+        return std::nullopt;
     }
-    return std::nullopt;
+    return it->second;
 }
 
 bool GeometryStorage::contains(ID id) const noexcept {
     return m_index.contains(id);
 }
 
-
-void GeometryStorage::remove(ID id, bool forceCascade) {
-    auto it = m_index.find(id);
-    if (it == m_index.end()) {
-        throw std::runtime_error("ID not found");
-    }
-    
-    const FigureEntry& entry = it->second;
-    
-    if (entry.type == FigureType::ET_POINT2D) {
-        std::vector<ID> dependents = getDependents(id);
-        
-        if (!dependents.empty()) {
-            if (!forceCascade) {
-                throw std::runtime_error("Dependencies exist");
-            }
-            
-            for (ID depId : dependents) {
-                try {
-                    remove(depId, false);
-                } catch (const std::runtime_error&) {
-                    // ignore if already removed
-                }
-            }
-        }
-        
-        const Point2D* ptrPoint = static_cast<const Point2D*>(entry.ptr);
-        m_pointToID.erase(ptrPoint);
-        std::erase(m_pointIDs, id);
-    } else if (entry.type == FigureType::ET_LINE) {
-        std::erase(m_lineIDs, id);
-    } else if (entry.type == FigureType::ET_CIRCLE) {
-        std::erase(m_circleIDs, id);
-    } else if (entry.type == FigureType::ET_ARC) {
-        std::erase(m_arcIDs, id);
-    }
-    
-    m_index.erase(it);
-}
-
-void GeometryStorage::clear() noexcept {
-    m_points.clear();
-    m_lines.clear();
-    m_circles.clear();
-    m_arcs.clear();
-    m_index.clear();
-    m_pointToID.clear();
-    m_pointIDs.clear();
-    m_lineIDs.clear();
-    m_circleIDs.clear();
-    m_arcIDs.clear();
-    m_idGen.reset();
-}
-
-std::span<Point2D> GeometryStorage::allPoints() noexcept {
-    if (m_points.empty()) return {};
-    return std::span<Point2D>{&m_points.front(), m_points.size()};
-}
-
-std::span<const Point2D> GeometryStorage::allPoints() const noexcept {
-    if (m_points.empty()) return {};
-    return std::span<const Point2D>{&m_points.front(), m_points.size()};
-}
-
-std::span<Line2D> GeometryStorage::allLines() noexcept {
-    if (m_lines.empty()) return {};
-    return std::span<Line2D>{&m_lines.front(), m_lines.size()};
-}
-
-std::span<const Line2D> GeometryStorage::allLines() const noexcept {
-    if (m_lines.empty()) return {};
-    return std::span<const Line2D>{&m_lines.front(), m_lines.size()};
-}
-
-std::span<Circle2D> GeometryStorage::allCircles() noexcept {
-    if (m_circles.empty()) return {};
-    return std::span<Circle2D>{&m_circles.front(), m_circles.size()};
-}
-
-std::span<const Circle2D> GeometryStorage::allCircles() const noexcept {
-    if (m_circles.empty()) return {};
-    return std::span<const Circle2D>{&m_circles.front(), m_circles.size()};
-}
-
-std::span<Arc2D> GeometryStorage::allArcs() noexcept {
-    if (m_arcs.empty()) return {};
-    return std::span<Arc2D>{&m_arcs.front(), m_arcs.size()};
-}
-
-std::span<const Arc2D> GeometryStorage::allArcs() const noexcept {
-    if (m_arcs.empty()) return {};
-    return std::span<const Arc2D>{&m_arcs.front(), m_arcs.size()};
-}
-
 std::vector<ID> GeometryStorage::getIDsByType(FigureType type) const {
     switch (type) {
-        case FigureType::ET_POINT2D:
-            return m_pointIDs;
-        case FigureType::ET_LINE:
-            return m_lineIDs;
-        case FigureType::ET_CIRCLE:
-            return m_circleIDs;
-        case FigureType::ET_ARC:
-            return m_arcIDs;
+        case FigureType::ET_POINT2D: {
+            std::vector<ID> ids;
+            ids.reserve(m_pointsWithIds.size());
+            for (const auto& r : m_pointsWithIds) {
+                ids.push_back(r.id);
+            }
+            return ids;
+        }
+        case FigureType::ET_LINE: {
+            std::vector<ID> ids;
+            ids.reserve(m_linesWithIds.size());
+            for (const auto& r : m_linesWithIds) {
+                ids.push_back(r.id);
+            }
+            return ids;
+        }
+        case FigureType::ET_CIRCLE: {
+            std::vector<ID> ids;
+            ids.reserve(m_circlesWithIds.size());
+            for (const auto& r : m_circlesWithIds) {
+                ids.push_back(r.id);
+            }
+            return ids;
+        }
+        case FigureType::ET_ARC: {
+            std::vector<ID> ids;
+            ids.reserve(m_arcsWithIds.size());
+            for (const auto& r : m_arcsWithIds) {
+                ids.push_back(r.id);
+            }
+            return ids;
+        }
         default:
             return {};
     }
-}
-
-const std::unordered_map<ID, FigureEntry>& GeometryStorage::allEntries() const noexcept {
-    return m_index;
 }
 
 std::size_t GeometryStorage::size() const noexcept {
@@ -240,19 +371,19 @@ std::size_t GeometryStorage::size() const noexcept {
 }
 
 std::size_t GeometryStorage::pointCount() const noexcept {
-    return m_pointIDs.size();
+    return m_pointsWithIds.size();
 }
 
 std::size_t GeometryStorage::lineCount() const noexcept {
-    return m_lineIDs.size();
+    return m_linesWithIds.size();
 }
 
 std::size_t GeometryStorage::circleCount() const noexcept {
-    return m_circleIDs.size();
+    return m_circlesWithIds.size();
 }
 
 std::size_t GeometryStorage::arcCount() const noexcept {
-    return m_arcIDs.size();
+    return m_arcsWithIds.size();
 }
 
 bool GeometryStorage::empty() const noexcept {
@@ -264,223 +395,101 @@ const ID& GeometryStorage::currentID() const noexcept {
 }
 
 std::vector<ID> GeometryStorage::getDependents(ID pointId) const {
-    std::vector<ID> result;
-    
-    auto entryOpt = getEntry(pointId);
-    if (!entryOpt || entryOpt->type != FigureType::ET_POINT2D) {
-        return result;
+    if (!tryPointId(pointId)) {
+        return {};
     }
-    
-    const Point2D* targetPoint = static_cast<const Point2D*>(entryOpt->ptr);
-    
-    for (const auto& [id, entry] : m_index) {
-        switch (entry.type) {
-            case FigureType::ET_LINE: {
-                const Line2D* line = static_cast<const Line2D*>(entry.ptr);
-                if (line->p1 == targetPoint || line->p2 == targetPoint) {
-                    result.push_back(id);
-                }
-                break;
-            }
-            case FigureType::ET_CIRCLE: {
-                const Circle2D* circle = static_cast<const Circle2D*>(entry.ptr);
-                if (circle->center == targetPoint) {
-                    result.push_back(id);
-                }
-                break;
-            }
-            case FigureType::ET_ARC: {
-                const Arc2D* arc = static_cast<const Arc2D*>(entry.ptr);
-                if (arc->p1 == targetPoint || arc->p2 == targetPoint || arc->p_center == targetPoint) {
-                    result.push_back(id);
-                }
-                break;
-            }
-            default:
-                break;
-        }
-    }
-    
-    return result;
+    return m_deps.dependentsOfPoint(pointId);
 }
 
 std::vector<ID> GeometryStorage::getDependencies(ID id) const {
-    std::vector<ID> result;
-    
-    auto entryOpt = getEntry(id);
-    if (!entryOpt) {
-        return result;
+    auto it = m_index.find(id);
+    if (it == m_index.end() || it->second.type == FigureType::ET_POINT2D) {
+        return {};
     }
-    
-    std::vector<const Point2D*> pointPtrs;
-    
-    switch (entryOpt->type) {
-        case FigureType::ET_POINT2D:
-            break;
-        case FigureType::ET_LINE: {
-            const Line2D* line = static_cast<const Line2D*>(entryOpt->ptr);
-            pointPtrs = {line->p1, line->p2};
-            break;
-        }
-        case FigureType::ET_CIRCLE: {
-            const Circle2D* circle = static_cast<const Circle2D*>(entryOpt->ptr);
-            pointPtrs = {circle->center};
-            break;
-        }
-        case FigureType::ET_ARC: {
-            const Arc2D* arc = static_cast<const Arc2D*>(entryOpt->ptr);
-            pointPtrs = {arc->p1, arc->p2, arc->p_center};
-            break;
-        }
-    }
-    
-    for (const Point2D* ptr : pointPtrs) {
-        auto idOpt = findPointID(ptr);
-        if (idOpt) {
-            result.push_back(*idOpt);
-        }
-    }
-    
-    return result;
-}
-
-std::vector<std::pair<ID, const Point2D*>> GeometryStorage::allPointsWithID() const {
-    std::vector<std::pair<ID, const Point2D*>> result;
-    result.reserve(m_pointIDs.size());
-    for (ID id : m_pointIDs) {
-        auto it = m_index.find(id);
-        if (it != m_index.end()) {
-            result.emplace_back(id, static_cast<const Point2D*>(it->second.ptr));
-        }
-    }
-    return result;
-}
-
-std::vector<std::pair<ID, const Line2D*>> GeometryStorage::allLinesWithID() const {
-    std::vector<std::pair<ID, const Line2D*>> result;
-    result.reserve(m_lineIDs.size());
-    for (ID id : m_lineIDs) {
-        auto it = m_index.find(id);
-        if (it != m_index.end()) {
-            result.emplace_back(id, static_cast<const Line2D*>(it->second.ptr));
-        }
-    }
-    return result;
-}
-
-std::vector<std::pair<ID, const Circle2D*>> GeometryStorage::allCirclesWithID() const {
-    std::vector<std::pair<ID, const Circle2D*>> result;
-    result.reserve(m_circleIDs.size());
-    for (ID id : m_circleIDs) {
-        auto it = m_index.find(id);
-        if (it != m_index.end()) {
-            result.emplace_back(id, static_cast<const Circle2D*>(it->second.ptr));
-        }
-    }
-    return result;
-}
-
-std::vector<std::pair<ID, const Arc2D*>> GeometryStorage::allArcsWithID() const {
-    std::vector<std::pair<ID, const Arc2D*>> result;
-    result.reserve(m_arcIDs.size());
-    for (ID id : m_arcIDs) {
-        auto it = m_index.find(id);
-        if (it != m_index.end()) {
-            result.emplace_back(id, static_cast<const Arc2D*>(it->second.ptr));
-        }
-    }
-    return result;
-}
-
-std::optional<ID> GeometryStorage::findPointID(const Point2D* ptr) const noexcept {
-    auto it = m_pointToID.find(ptr);
-    if (it != m_pointToID.end()) {
-        return it->second;
-    }
-    return std::nullopt;
+    const auto& v = m_deps.pointsForFigure(id);
+    return {v.begin(), v.end()};
 }
 
 ObjectGraph GeometryStorage::buildObjectGraph() const {
-    ObjectGraph graph;
-    const ID helperWeight = ID(static_cast<unsigned long long>(-1));
+    return GeometryGraphBuilder::buildObjectGraph(*this);
+}
 
-    for (const auto& [id, entry] : m_index) {
-        graph.addVertex(id);
+std::optional<ObjectGraph> GeometryStorage::buildObjectSubgraph(ID id) const {
+    return GeometryGraphBuilder::buildObjectSubgraph(*this, id);
+}
+
+#ifndef NDEBUG
+bool GeometryStorage::validate() const noexcept {
+    const std::size_t totalCached =
+        m_pointsWithIds.size() + m_linesWithIds.size() + m_circlesWithIds.size() + m_arcsWithIds.size();
+    if (m_index.size() != totalCached) {
+        return false;
     }
-
-    for (const auto& [id, entry] : m_index) {
-        switch (entry.type) {
-            case FigureType::ET_LINE: {
-                const Line2D* line = static_cast<const Line2D*>(entry.ptr);
-                if (auto p1 = findPointID(line->p1)) {
-                    graph.addEdge(id, *p1, helperWeight);
+    if (m_index.size() != m_pointWithIdPos.size() + m_lineWithIdPos.size() + m_circleWithIdPos.size() +
+                               m_arcWithIdPos.size()) {
+        return false;
+    }
+    for (const auto& [id, ent] : m_index) {
+        switch (ent.type) {
+            case FigureType::ET_POINT2D:
+                if (ent.slot >= m_pointSlots.size() || !m_pointSlots[ent.slot]) {
+                    return false;
                 }
-                if (auto p2 = findPointID(line->p2)) {
-                    graph.addEdge(id, *p2, helperWeight);
-                }
-                break;
-            }
-            case FigureType::ET_CIRCLE: {
-                const Circle2D* circle = static_cast<const Circle2D*>(entry.ptr);
-                if (auto c = findPointID(circle->center)) {
-                    graph.addEdge(id, *c, helperWeight);
+                if (m_pointSlots[ent.slot].get() != get<Point2D>(id)) {
+                    return false;
                 }
                 break;
-            }
-            case FigureType::ET_ARC: {
-                const Arc2D* arc = static_cast<const Arc2D*>(entry.ptr);
-                if (auto p1 = findPointID(arc->p1)) {
-                    graph.addEdge(id, *p1, helperWeight);
-                }
-                if (auto p2 = findPointID(arc->p2)) {
-                    graph.addEdge(id, *p2, helperWeight);
-                }
-                if (auto c = findPointID(arc->p_center)) {
-                    graph.addEdge(id, *c, helperWeight);
+            case FigureType::ET_LINE:
+                if (ent.slot >= m_lineSlots.size() || !m_lineSlots[ent.slot]) {
+                    return false;
                 }
                 break;
-            }
+            case FigureType::ET_CIRCLE:
+                if (ent.slot >= m_circleSlots.size() || !m_circleSlots[ent.slot]) {
+                    return false;
+                }
+                break;
+            case FigureType::ET_ARC:
+                if (ent.slot >= m_arcSlots.size() || !m_arcSlots[ent.slot]) {
+                    return false;
+                }
+                break;
             default:
-                break;
+                return false;
         }
     }
-
-    return graph;
-}
-
-ObjectGraph GeometryStorage::buildObjectSubgraph(ID id) const {
-    auto typeOpt = getType(id);
-    if (!typeOpt) {
-        throw std::runtime_error("ID not found");
-    }
-
-    ObjectGraph graph;
-    const ID helperWeight = ID(static_cast<unsigned long long>(-1));
-
-    graph.addVertex(id);
-
-    if (*typeOpt == FigureType::ET_POINT2D) {
-        auto dependents = getDependents(id);
-        for (const ID depId : dependents) {
-            graph.addVertex(depId);
-            graph.addEdge(id, depId, helperWeight);
-            auto depPoints = getDependencies(depId);
-            for (const ID pointId : depPoints) {
-                graph.addVertex(pointId);
-                graph.addEdge(depId, pointId, helperWeight);
-            }
+    for (const auto& r : m_pointsWithIds) {
+        if (!contains(r.id) || get<Point2D>(r.id) != r.ptr) {
+            return false;
         }
-        return graph;
     }
-
-    auto dependencies = getDependencies(id);
-    for (const ID depId : dependencies) {
-        graph.addVertex(depId);
-        graph.addEdge(id, depId, helperWeight);
+    for (const auto& r : m_linesWithIds) {
+        if (!contains(r.id) || get<Line2D>(r.id) != r.ptr) {
+            return false;
+        }
+        const auto& pts = m_deps.pointsForFigure(r.id);
+        if (pts.size() != 2) {
+            return false;
+        }
     }
-
-    return graph;
+    for (const auto& r : m_circlesWithIds) {
+        if (!contains(r.id) || get<Circle2D>(r.id) != r.ptr) {
+            return false;
+        }
+        if (m_deps.pointsForFigure(r.id).size() != 1) {
+            return false;
+        }
+    }
+    for (const auto& r : m_arcsWithIds) {
+        if (!contains(r.id) || get<Arc2D>(r.id) != r.ptr) {
+            return false;
+        }
+        if (m_deps.pointsForFigure(r.id).size() != 3) {
+            return false;
+        }
+    }
+    return true;
 }
+#endif
 
-}
-
+} // namespace OurPaintDCM::Figures

--- a/src/system/RequirementSystem.cpp
+++ b/src/system/RequirementSystem.cpp
@@ -1,6 +1,18 @@
 #include "RequirementSystem.h"
 #include <stdexcept>
 
+namespace {
+
+template <typename T>
+T* requireGeometry(T* ptr) {
+    if (ptr == nullptr) {
+        throw std::runtime_error("Invalid geometry ID or type mismatch");
+    }
+    return ptr;
+}
+
+} // namespace
+
 namespace OurPaintDCM::System {
 
 RequirementSystem::RequirementSystem(Figures::GeometryStorage* storage)
@@ -14,38 +26,38 @@ Utils::ID RequirementSystem::addRequirement(const Utils::RequirementDescriptor& 
 
     switch (descriptor.type) {
         case Utils::RequirementType::ET_POINTLINEDIST: {
-            auto* point = _storage->get<Figures::Point2D>(ids[0]);
-            auto* line = _storage->get<Figures::Line2D>(ids[1]);
+            auto* point = requireGeometry(_storage->get<Figures::Point2D>(ids[0]));
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createPointLineDist(point, line, descriptor.param.value());
             break;
         }
         case Utils::RequirementType::ET_POINTONLINE: {
-            auto* point = _storage->get<Figures::Point2D>(ids[0]);
-            auto* line = _storage->get<Figures::Line2D>(ids[1]);
+            auto* point = requireGeometry(_storage->get<Figures::Point2D>(ids[0]));
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createPointOnLine(point, line);
             break;
         }
         case Utils::RequirementType::ET_POINTPOINTDIST: {
-            auto* p1 = _storage->get<Figures::Point2D>(ids[0]);
-            auto* p2 = _storage->get<Figures::Point2D>(ids[1]);
+            auto* p1 = requireGeometry(_storage->get<Figures::Point2D>(ids[0]));
+            auto* p2 = requireGeometry(_storage->get<Figures::Point2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createPointPointDist(p1, p2, descriptor.param.value());
             break;
         }
         case Utils::RequirementType::ET_POINTONPOINT: {
-            auto* p1 = _storage->get<Figures::Point2D>(ids[0]);
-            auto* p2 = _storage->get<Figures::Point2D>(ids[1]);
+            auto* p1 = requireGeometry(_storage->get<Figures::Point2D>(ids[0]));
+            auto* p2 = requireGeometry(_storage->get<Figures::Point2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createPointOnPoint(p1, p2);
             break;
         }
         case Utils::RequirementType::ET_LINECIRCLEDIST: {
-            auto* line = _storage->get<Figures::Line2D>(ids[0]);
-            auto* circle = _storage->get<Figures::Circle2D>(ids[1]);
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
+            auto* circle = requireGeometry(_storage->get<Figures::Circle2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createLineCircleDist(line, circle, descriptor.param.value());
             break;
         }
         case Utils::RequirementType::ET_LINEONCIRCLE: {
-            auto* line = _storage->get<Figures::Line2D>(ids[0]);
-            auto* circle = _storage->get<Figures::Circle2D>(ids[1]);
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
+            auto* circle = requireGeometry(_storage->get<Figures::Circle2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createLineOnCircle(line, circle);
             break;
         }
@@ -54,52 +66,52 @@ Utils::ID RequirementSystem::addRequirement(const Utils::RequirementDescriptor& 
             throw std::runtime_error("LineInCircle requirement is not yet supported via unified interface");
         }
         case Utils::RequirementType::ET_LINELINEPARALLEL: {
-            auto* l1 = _storage->get<Figures::Line2D>(ids[0]);
-            auto* l2 = _storage->get<Figures::Line2D>(ids[1]);
+            auto* l1 = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
+            auto* l2 = requireGeometry(_storage->get<Figures::Line2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createLineLineParallel(l1, l2);
             break;
         }
         case Utils::RequirementType::ET_LINELINEPERPENDICULAR: {
-            auto* l1 = _storage->get<Figures::Line2D>(ids[0]);
-            auto* l2 = _storage->get<Figures::Line2D>(ids[1]);
+            auto* l1 = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
+            auto* l2 = requireGeometry(_storage->get<Figures::Line2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createLineLinePerpendicular(l1, l2);
             break;
         }
         case Utils::RequirementType::ET_LINELINEANGLE: {
-            auto* l1 = _storage->get<Figures::Line2D>(ids[0]);
-            auto* l2 = _storage->get<Figures::Line2D>(ids[1]);
+            auto* l1 = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
+            auto* l2 = requireGeometry(_storage->get<Figures::Line2D>(ids[1]));
             func = Function::RequirementFunctionFactory::createLineLineAngle(l1, l2, descriptor.param.value());
             break;
         }
         case Utils::RequirementType::ET_VERTICAL: {
-            auto* line = _storage->get<Figures::Line2D>(ids[0]);
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
             func = Function::RequirementFunctionFactory::createVertical(line);
             break;
         }
         case Utils::RequirementType::ET_HORIZONTAL: {
-            auto* line = _storage->get<Figures::Line2D>(ids[0]);
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
             func = Function::RequirementFunctionFactory::createHorizontal(line);
             break;
         }
         case Utils::RequirementType::ET_ARCCENTERONPERPENDICULAR: {
-            auto* arc = _storage->get<Figures::Arc2D>(ids[0]);
+            auto* arc = requireGeometry(_storage->get<Figures::Arc2D>(ids[0]));
             func = Function::RequirementFunctionFactory::createArcCenterOnPerpendicular(arc);
             break;
         }
         case Utils::RequirementType::ET_FIXPOINT: {
-            auto* point = _storage->get<Figures::Point2D>(ids[0]);
+            auto* point = requireGeometry(_storage->get<Figures::Point2D>(ids[0]));
             auto funcs = Function::RequirementFunctionFactory::createFixPoint(point);
             for (auto& f : funcs) addFunction(f);
             break;
         }
         case Utils::RequirementType::ET_FIXLINE: {
-            auto* line = _storage->get<Figures::Line2D>(ids[0]);
+            auto* line = requireGeometry(_storage->get<Figures::Line2D>(ids[0]));
             auto funcs = Function::RequirementFunctionFactory::createFixLine(line);
             for (auto& f : funcs) addFunction(f);
             break;
         }
         case Utils::RequirementType::ET_FIXCIRCLE: {
-            auto* circle = _storage->get<Figures::Circle2D>(ids[0]);
+            auto* circle = requireGeometry(_storage->get<Figures::Circle2D>(ids[0]));
             auto funcs = Function::RequirementFunctionFactory::createFixCircle(circle);
             for (auto& f : funcs) addFunction(f);
             break;

--- a/tests/DCMManagerGTEST.cpp
+++ b/tests/DCMManagerGTEST.cpp
@@ -324,10 +324,7 @@ TEST_F(DCMManagerTest, StorageAccess) {
     auto p = manager.addFigure(FigureDescriptor::point(5.0, 10.0));
 
     const auto& constStorage = manager.getStorage();
-    auto& mutableStorage = manager.storage();
-
     EXPECT_TRUE(constStorage.contains(p));
-    EXPECT_TRUE(mutableStorage.contains(p));
 }
 
 TEST_F(DCMManagerTest, RequirementSystemAccess) {

--- a/tests/DCMManagerGTEST.cpp
+++ b/tests/DCMManagerGTEST.cpp
@@ -119,6 +119,21 @@ TEST_F(DCMManagerTest, GetAllFigures) {
     EXPECT_EQ(figures.size(), 3);
 }
 
+TEST_F(DCMManagerTest, GetAllPointsWithID) {
+    auto p1 = manager.addFigure(FigureDescriptor::point(0.0, 0.0));
+    auto p2 = manager.addFigure(FigureDescriptor::point(10.0, 0.0));
+    auto p3 = manager.addFigure(FigureDescriptor::point(5.0, 5.0));
+    auto l1 = manager.addFigure(FigureDescriptor::line(p1, p2));
+
+    auto points = manager.getAllPointsWithID();
+    EXPECT_EQ(points.size(), 3);
+    // Check that all are points and have correct IDs
+    for (const auto& [id, desc] : points) {
+        EXPECT_EQ(desc.type, FigureType::ET_POINT2D);
+        EXPECT_TRUE(desc.x.has_value() && desc.y.has_value());
+    }
+}
+
 TEST_F(DCMManagerTest, AddRequirement) {
     auto p1 = manager.addFigure(FigureDescriptor::point(0.0, 0.0));
     auto p2 = manager.addFigure(FigureDescriptor::point(10.0, 0.0));

--- a/tests/DCMManagerGTEST.cpp
+++ b/tests/DCMManagerGTEST.cpp
@@ -125,10 +125,10 @@ TEST_F(DCMManagerTest, GetAllPointsWithID) {
     auto p3 = manager.addFigure(FigureDescriptor::point(5.0, 5.0));
     auto l1 = manager.addFigure(FigureDescriptor::line(p1, p2));
 
-    auto points = manager.getAllPointsWithID();
+    auto points = manager.getAllPoints();
     EXPECT_EQ(points.size(), 3);
-    // Check that all are points and have correct IDs
-    for (const auto& [id, desc] : points) {
+    // Check that all are points and have correct values
+    for (const auto& desc : points) {
         EXPECT_EQ(desc.type, FigureType::ET_POINT2D);
         EXPECT_TRUE(desc.x.has_value() && desc.y.has_value());
     }

--- a/tests/DragOptimizersBenchmarkGTEST.cpp
+++ b/tests/DragOptimizersBenchmarkGTEST.cpp
@@ -1,0 +1,448 @@
+#include <gtest/gtest.h>
+
+#include "DCMManager.h"
+
+#include "GradientOptimizer.h"
+#include "AdamOptimizer.h"
+#include "LMWithSparse.h"
+#include "LSMTask.h"
+#include "LSMFORLMTask.h"
+
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace OurPaintDCM;
+using namespace OurPaintDCM::Utils;
+
+namespace {
+
+class RequirementDerivativeAdapter;
+
+class RequirementFunctionAdapter : public Function {
+    std::shared_ptr<OurPaintDCM::Function::RequirementFunction> req_;
+public:
+    explicit RequirementFunctionAdapter(std::shared_ptr<OurPaintDCM::Function::RequirementFunction> req)
+        : req_(std::move(req)) {}
+
+    double evaluate() const override { return req_->evaluate(); }
+    ::Function* derivative(Variable* var) const override;
+    ::Function* clone() const override { return new RequirementFunctionAdapter(req_); }
+    std::string to_string() const override { return "ReqFunc"; }
+};
+
+class RequirementDerivativeAdapter : public Function {
+    std::shared_ptr<OurPaintDCM::Function::RequirementFunction> req_;
+    double* var_;
+public:
+    RequirementDerivativeAdapter(std::shared_ptr<OurPaintDCM::Function::RequirementFunction> req, double* var)
+        : req_(std::move(req)), var_(var) {}
+
+    double evaluate() const override {
+        auto grad = req_->gradient();
+        auto it = grad.find(var_);
+        return (it != grad.end()) ? it->second : 0.0;
+    }
+    ::Function* derivative(Variable*) const override { return new Constant(0.0); }
+    ::Function* clone() const override { return new RequirementDerivativeAdapter(req_, var_); }
+    std::string to_string() const override { return "ReqDeriv"; }
+};
+
+::Function* RequirementFunctionAdapter::derivative(Variable* var) const {
+    return new RequirementDerivativeAdapter(req_, var->value);
+}
+
+struct BenchConfig {
+    int objects;
+    int requirements;
+};
+
+struct BenchResult {
+    std::string name;
+    long long buildMs;
+    long long optimizeMs;
+    bool converged;
+    double error;
+};
+
+struct DragStepResult {
+    std::string name;
+    int steps;
+    long long totalMs;
+    double avgStepMs;
+    int convergedSteps;
+    double finalError;
+};
+
+std::vector<double> snapshotValues(const std::vector<VAR>& allVars) {
+    std::vector<double> values;
+    values.reserve(allVars.size());
+    for (auto* v : allVars) values.push_back(*v);
+    return values;
+}
+
+void restoreValues(const std::vector<VAR>& allVars, const std::vector<double>& values) {
+    for (size_t i = 0; i < allVars.size(); ++i) {
+        *allVars[i] = values[i];
+    }
+}
+
+std::vector<Variable*> makeMathVars(const std::vector<VAR>& allVars) {
+    std::vector<Variable*> vars;
+    vars.reserve(allVars.size());
+    for (auto* v : allVars) vars.push_back(new Variable(v));
+    return vars;
+}
+
+std::vector<::Function*> makeMathFuncs(
+    const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& reqFuncs) {
+    std::vector<::Function*> funcs;
+    funcs.reserve(reqFuncs.size());
+    for (const auto& rf : reqFuncs) funcs.push_back(new RequirementFunctionAdapter(rf));
+    return funcs;
+}
+
+BenchResult runGradient(const std::vector<VAR>& allVars,
+                        const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& reqFuncs,
+                        const std::vector<double>& savedValues) {
+    restoreValues(allVars, savedValues);
+    auto vars = makeMathVars(allVars);
+    auto funcs = makeMathFuncs(reqFuncs);
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    LSMTask task(funcs, vars);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    GradientOptimizer optimizer(0.01, 100);
+    optimizer.setTask(&task);
+    optimizer.optimize();
+    const auto t2 = std::chrono::high_resolution_clock::now();
+
+    for (auto* v : vars) delete v;
+
+    return {
+        "Gradient",
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count(),
+        optimizer.isConverged(),
+        optimizer.getCurrentError()
+    };
+}
+
+BenchResult runAdam(const std::vector<VAR>& allVars,
+                    const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& reqFuncs,
+                    const std::vector<double>& savedValues) {
+    restoreValues(allVars, savedValues);
+    auto vars = makeMathVars(allVars);
+    auto funcs = makeMathFuncs(reqFuncs);
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    LSMFORLMTask task(funcs, vars);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    AdamOptimizer optimizer(0.001, 0.9, 0.999, 1e-8, 1e-6, 100);
+    optimizer.setTask(&task);
+    optimizer.optimize();
+    const auto t2 = std::chrono::high_resolution_clock::now();
+
+    for (auto* f : funcs) delete f;
+    for (auto* v : vars) delete v;
+
+    return {
+        "Adam",
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count(),
+        optimizer.isConverged(),
+        optimizer.getCurrentError()
+    };
+}
+
+BenchResult runLMSparse(const std::vector<VAR>& allVars,
+                        const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& reqFuncs,
+                        const std::vector<double>& savedValues) {
+    restoreValues(allVars, savedValues);
+    auto vars = makeMathVars(allVars);
+    auto funcs = makeMathFuncs(reqFuncs);
+
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    LSMFORLMTask task(funcs, vars);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+
+    LMSparse optimizer(100);
+    optimizer.setTask(&task);
+    optimizer.optimize();
+    const auto t2 = std::chrono::high_resolution_clock::now();
+
+    for (auto* f : funcs) delete f;
+    for (auto* v : vars) delete v;
+
+    return {
+        "LMSparse",
+        std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count(),
+        std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1).count(),
+        optimizer.isConverged(),
+        optimizer.getCurrentError()
+    };
+}
+
+void printResults(const BenchConfig& cfg, const std::vector<BenchResult>& results) {
+    std::cout << "\n===== Drag Optimizer Benchmark =====\n";
+    std::cout << "Objects: " << cfg.objects << ", Requirements: " << cfg.requirements << '\n';
+    std::cout << std::left
+              << std::setw(12) << "Optimizer"
+              << std::setw(12) << "Build(ms)"
+              << std::setw(12) << "Opt(ms)"
+              << std::setw(12) << "Total(ms)"
+              << std::setw(10) << "Conv"
+              << "Error\n";
+    for (const auto& r : results) {
+        std::cout << std::left
+                  << std::setw(12) << r.name
+                  << std::setw(12) << r.buildMs
+                  << std::setw(12) << r.optimizeMs
+                  << std::setw(12) << (r.buildMs + r.optimizeMs)
+                  << std::setw(10) << (r.converged ? "yes" : "no")
+                  << r.error << '\n';
+    }
+    std::cout << "===================================\n";
+}
+
+void printDragStepResults(int objects, int requirements, double delta, int steps,
+                          const std::vector<DragStepResult>& results) {
+    std::cout << "\n===== Small-Shift Drag Scenario =====\n";
+    std::cout << "Objects: " << objects
+              << ", Requirements: " << requirements
+              << ", Delta: " << delta
+              << ", Steps: " << steps << '\n';
+    std::cout << std::left
+              << std::setw(12) << "Optimizer"
+              << std::setw(10) << "Steps"
+              << std::setw(12) << "Total(ms)"
+              << std::setw(14) << "AvgStep(ms)"
+              << std::setw(12) << "ConvSteps"
+              << "FinalError\n";
+    for (const auto& r : results) {
+        std::cout << std::left
+                  << std::setw(12) << r.name
+                  << std::setw(10) << r.steps
+                  << std::setw(12) << r.totalMs
+                  << std::setw(14) << std::fixed << std::setprecision(3) << r.avgStepMs
+                  << std::setw(12) << r.convergedSteps
+                  << r.finalError << '\n';
+    }
+    std::cout << "=====================================\n";
+}
+
+template <typename OptimizerRunner>
+DragStepResult runSmallShiftScenario(const std::string& name,
+                                     const std::vector<VAR>& allVars,
+                                     const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& reqFuncs,
+                                     const std::vector<double>& savedValues,
+                                     int steps,
+                                     double delta,
+                                     OptimizerRunner&& runOptimizerOnce) {
+    restoreValues(allVars, savedValues);
+    const auto t0 = std::chrono::high_resolution_clock::now();
+
+    int convergedSteps = 0;
+    double finalError = 0.0;
+    for (int i = 0; i < steps; ++i) {
+        *allVars.front() += delta; // emulate dragging one coordinate by +0.01
+        const auto [converged, error] = runOptimizerOnce(allVars, reqFuncs);
+        if (converged) ++convergedSteps;
+        finalError = error;
+    }
+
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    const auto totalMs = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+    const double avgMs = static_cast<double>(totalMs) / static_cast<double>(steps);
+    return {name, steps, totalMs, avgMs, convergedSteps, finalError};
+}
+
+} // namespace
+
+class DragOptimizersBenchmark : public ::testing::TestWithParam<BenchConfig> {
+protected:
+    DCMManager manager_;
+
+    void buildSingleComponentModel(int objectCount, int requirementCount) {
+        const int pointCount = objectCount / 2;
+        const int lineCount = objectCount - pointCount;
+        ASSERT_GE(pointCount, 3);
+        ASSERT_GE(lineCount, 2);
+
+        std::vector<ID> points;
+        points.reserve(pointCount);
+
+        for (int i = 0; i < pointCount; ++i) {
+            const double x = static_cast<double>(i) * 10.0;
+            const double y = (i % 3 == 0) ? 0.15 : ((i % 3 == 1) ? -0.12 : 0.08);
+            points.push_back(manager_.addFigure(FigureDescriptor::point(x, y)));
+        }
+
+        std::vector<ID> lines;
+        lines.reserve(lineCount);
+        for (int i = 0; i < lineCount; ++i) {
+            const ID p1 = points[i % pointCount];
+            const ID p2 = points[(i + 1) % pointCount];
+            lines.push_back(manager_.addFigure(FigureDescriptor::line(p1, p2)));
+        }
+
+        int created = 0;
+        for (int i = 0; i < pointCount && created < requirementCount; ++i) {
+            const ID p1 = points[i];
+            const ID p2 = points[(i + 1) % pointCount];
+            manager_.addRequirement(RequirementDescriptor::pointPointDist(p1, p2, 10.0));
+            ++created;
+        }
+        for (int i = 0; i < lineCount && created < requirementCount; ++i) {
+            manager_.addRequirement(RequirementDescriptor::horizontal(lines[i]));
+            ++created;
+        }
+        for (int i = 0; i + 1 < lineCount && created < requirementCount; ++i) {
+            manager_.addRequirement(RequirementDescriptor::lineLineParallel(lines[i], lines[i + 1]));
+            ++created;
+        }
+
+        ASSERT_EQ(created, requirementCount);
+        ASSERT_EQ(manager_.figureCount(), static_cast<size_t>(objectCount));
+        ASSERT_EQ(manager_.requirementCount(), static_cast<size_t>(requirementCount));
+        ASSERT_EQ(manager_.getComponentCount(), 1U);
+    }
+};
+
+TEST_P(DragOptimizersBenchmark, CompareAdamGradientAndLMSparse) {
+    const BenchConfig cfg = GetParam();
+    buildSingleComponentModel(cfg.objects, cfg.requirements);
+
+    auto& system = manager_.requirementSystem();
+    const auto& reqFuncs = system.getFunctions();
+    const auto allVars = system.getAllVars();
+    ASSERT_FALSE(reqFuncs.empty());
+    ASSERT_FALSE(allVars.empty());
+
+    const auto savedValues = snapshotValues(allVars);
+
+    std::vector<BenchResult> results;
+    results.reserve(3);
+    results.push_back(runAdam(allVars, reqFuncs, savedValues));
+    results.push_back(runGradient(allVars, reqFuncs, savedValues));
+    results.push_back(runLMSparse(allVars, reqFuncs, savedValues));
+
+    printResults(cfg, results);
+
+    EXPECT_EQ(results.size(), 3U);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    LargeButSafeModels,
+    DragOptimizersBenchmark,
+    ::testing::Values(
+        BenchConfig{100, 50},
+        BenchConfig{125, 75},
+        BenchConfig{150, 100}
+    )
+);
+
+TEST(DragOptimizersSmallShiftBenchmark, CompareOnRepeatedSmallShifts) {
+    DCMManager manager;
+
+    constexpr int objects = 100;
+    constexpr int requirements = 75;
+    constexpr int steps = 15;
+    constexpr double delta = 0.01;
+
+    const int pointCount = objects / 2;
+    const int lineCount = objects - pointCount;
+
+    std::vector<ID> points;
+    points.reserve(pointCount);
+    for (int i = 0; i < pointCount; ++i) {
+        points.push_back(manager.addFigure(FigureDescriptor::point(static_cast<double>(i) * 10.0, 0.0)));
+    }
+
+    std::vector<ID> lines;
+    lines.reserve(lineCount);
+    for (int i = 0; i < lineCount; ++i) {
+        lines.push_back(manager.addFigure(FigureDescriptor::line(points[i % pointCount], points[(i + 1) % pointCount])));
+    }
+
+    int created = 0;
+    for (int i = 0; i < pointCount && created < requirements; ++i, ++created) {
+        manager.addRequirement(RequirementDescriptor::pointPointDist(points[i], points[(i + 1) % pointCount], 10.0));
+    }
+    for (int i = 0; i < lineCount && created < requirements; ++i, ++created) {
+        manager.addRequirement(RequirementDescriptor::horizontal(lines[i]));
+    }
+    for (int i = 0; i + 1 < lineCount && created < requirements; ++i, ++created) {
+        manager.addRequirement(RequirementDescriptor::lineLineParallel(lines[i], lines[i + 1]));
+    }
+
+    ASSERT_EQ(created, requirements);
+    ASSERT_EQ(manager.getComponentCount(), 1U);
+
+    auto& system = manager.requirementSystem();
+    const auto& reqFuncs = system.getFunctions();
+    const auto allVars = system.getAllVars();
+    ASSERT_FALSE(reqFuncs.empty());
+    ASSERT_FALSE(allVars.empty());
+    const auto savedValues = snapshotValues(allVars);
+
+    auto runGradientOnce = [](const std::vector<VAR>& vars,
+                              const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& funcs) {
+        auto mVars = makeMathVars(vars);
+        auto mFuncs = makeMathFuncs(funcs);
+        LSMTask task(mFuncs, mVars);
+        GradientOptimizer optimizer(0.01, 100);
+        optimizer.setTask(&task);
+        optimizer.optimize();
+        const bool converged = optimizer.isConverged();
+        const double error = optimizer.getCurrentError();
+        for (auto* v : mVars) delete v;
+        return std::make_pair(converged, error);
+    };
+
+    auto runAdamOnce = [](const std::vector<VAR>& vars,
+                          const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& funcs) {
+        auto mVars = makeMathVars(vars);
+        auto mFuncs = makeMathFuncs(funcs);
+        LSMFORLMTask task(mFuncs, mVars);
+        AdamOptimizer optimizer(0.001, 0.9, 0.999, 1e-8, 1e-6, 100);
+        optimizer.setTask(&task);
+        optimizer.optimize();
+        const bool converged = optimizer.isConverged();
+        const double error = optimizer.getCurrentError();
+        for (auto* f : mFuncs) delete f;
+        for (auto* v : mVars) delete v;
+        return std::make_pair(converged, error);
+    };
+
+    auto runLMSparseOnce = [](const std::vector<VAR>& vars,
+                              const std::vector<std::shared_ptr<OurPaintDCM::Function::RequirementFunction>>& funcs) {
+        auto mVars = makeMathVars(vars);
+        auto mFuncs = makeMathFuncs(funcs);
+        LSMFORLMTask task(mFuncs, mVars);
+        LMSparse optimizer(100);
+        optimizer.setTask(&task);
+        optimizer.optimize();
+        const bool converged = optimizer.isConverged();
+        const double error = optimizer.getCurrentError();
+        for (auto* f : mFuncs) delete f;
+        for (auto* v : mVars) delete v;
+        return std::make_pair(converged, error);
+    };
+
+    std::vector<DragStepResult> results;
+    results.reserve(3);
+    results.push_back(runSmallShiftScenario("Adam", allVars, reqFuncs, savedValues, steps, delta, runAdamOnce));
+    results.push_back(runSmallShiftScenario("Gradient", allVars, reqFuncs, savedValues, steps, delta, runGradientOnce));
+    results.push_back(runSmallShiftScenario("LMSparse", allVars, reqFuncs, savedValues, steps, delta, runLMSparseOnce));
+
+    printDragStepResults(objects, requirements, delta, steps, results);
+
+    EXPECT_EQ(results.size(), 3U);
+}

--- a/tests/Figures/GeometryStorageBenchmark.cpp
+++ b/tests/Figures/GeometryStorageBenchmark.cpp
@@ -1,0 +1,142 @@
+/**
+ * Micro-benchmarks for GeometryStorage (STEP 10).
+ * Run: GeometryStorageBenchmark --gtest_filter=GeometryStorageBench.*
+ * Timings go to stderr; tests always pass if invariants hold.
+ */
+#include <gtest/gtest.h>
+#include "GeometryStorage.h"
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <vector>
+
+using namespace OurPaintDCM::Figures;
+using namespace OurPaintDCM::Utils;
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+void reportMs(std::string_view label, Clock::duration d) {
+    const double ms =
+        std::chrono::duration<double, std::milli>(d).count();
+    std::cerr << "[GeometryStorageBench] " << label << ": " << ms << " ms\n";
+}
+
+} // namespace
+
+TEST(GeometryStorageBench, CreateManyPoints) {
+    constexpr int N = 50'000;
+    GeometryStorage storage;
+    const auto t0 = Clock::now();
+    for (int i = 0; i < N; ++i) {
+        (void)storage.createPoint(static_cast<double>(i), static_cast<double>(i * 2));
+    }
+    reportMs("createPoint x " + std::to_string(N), Clock::now() - t0);
+    EXPECT_EQ(static_cast<int>(storage.pointCount()), N);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageBench, LookupManyTimes) {
+    constexpr int N = 10'000;
+    constexpr int lookups = 200'000;
+    GeometryStorage storage;
+    std::vector<ID> ids;
+    ids.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        ids.push_back(storage.createPoint(static_cast<double>(i), 0.0));
+    }
+    const auto t0 = Clock::now();
+    volatile double sink = 0;
+    for (int k = 0; k < lookups; ++k) {
+        const ID id = ids[static_cast<std::size_t>(k % N)];
+        const Point2D* p = storage.get<Point2D>(id);
+        sink += p->x();
+    }
+    reportMs("get<Point2D> x " + std::to_string(lookups), Clock::now() - t0);
+    EXPECT_GT(sink, 0.0);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageBench, GetDependentsHub) {
+    constexpr int spokes = 20'000;
+    GeometryStorage storage;
+    const ID hub = storage.createPoint(0.0, 0.0);
+    const auto tCreate0 = Clock::now();
+    for (int i = 0; i < spokes; ++i) {
+        const ID rim = storage.createPoint(static_cast<double>(i), 1.0);
+        ASSERT_TRUE(storage.createLine(hub, rim).has_value());
+    }
+    reportMs("star createLine x " + std::to_string(spokes), Clock::now() - tCreate0);
+
+    const auto tDep0 = Clock::now();
+    std::vector<ID> deps = storage.getDependents(hub);
+    reportMs("getDependents(hub) degree=" + std::to_string(deps.size()), Clock::now() - tDep0);
+
+    EXPECT_EQ(deps.size(), static_cast<std::size_t>(spokes));
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageBench, RemoveCascadeFromHub) {
+    constexpr int spokes = 5'000;
+    GeometryStorage storage;
+    const ID hub = storage.createPoint(0.0, 0.0);
+    for (int i = 0; i < spokes; ++i) {
+        const ID rim = storage.createPoint(static_cast<double>(i), 1.0);
+        ASSERT_TRUE(storage.createLine(hub, rim).has_value());
+    }
+    const auto t0 = Clock::now();
+    EXPECT_EQ(storage.remove(hub, true), RemoveResult::Ok);
+    reportMs("remove(hub,cascade) after " + std::to_string(spokes) + " lines", Clock::now() - t0);
+    EXPECT_EQ(storage.lineCount(), 0u);
+    EXPECT_FALSE(storage.contains(hub));
+    EXPECT_EQ(storage.pointCount(), static_cast<std::size_t>(spokes));
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageBench, SubgraphBuild) {
+    constexpr int chain = 2'000;
+    GeometryStorage storage;
+    ID prev = storage.createPoint(0.0, 0.0);
+    for (int i = 1; i <= chain; ++i) {
+        const ID cur = storage.createPoint(static_cast<double>(i), 0.0);
+        ASSERT_TRUE(storage.createLine(prev, cur).has_value());
+        prev = cur;
+    }
+    const ID mid = prev;
+    const auto t0 = Clock::now();
+    auto gOpt = storage.buildObjectSubgraph(mid);
+    ASSERT_TRUE(gOpt.has_value());
+    reportMs("buildObjectSubgraph(chain n=" + std::to_string(chain + 1) + ")", Clock::now() - t0);
+    EXPECT_FALSE(gOpt->vertexCount() == 0);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageBench, ReuseSlotsStress) {
+    constexpr int cycles = 2'000;
+    GeometryStorage storage;
+    const auto t0 = Clock::now();
+    for (int c = 0; c < cycles; ++c) {
+        const ID a = storage.createPoint(0.0, 0.0);
+        const ID b = storage.createPoint(1.0, 0.0);
+        ASSERT_TRUE(storage.createLine(a, b).has_value());
+        EXPECT_EQ(storage.remove(a, true), RemoveResult::Ok);
+        EXPECT_EQ(storage.remove(b, false), RemoveResult::Ok);
+    }
+    reportMs("create/remove cycle x " + std::to_string(cycles), Clock::now() - t0);
+    EXPECT_TRUE(storage.empty());
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}

--- a/tests/Figures/GeometryStorageGTEST.cpp
+++ b/tests/Figures/GeometryStorageGTEST.cpp
@@ -10,18 +10,18 @@ namespace {
 bool containsId(const std::vector<ID>& ids, ID id) {
     return std::find(ids.begin(), ids.end(), id) != ids.end();
 }
-}
+} // namespace
 
 TEST(GeometryStorageTest, CreatePointAndAccess) {
     GeometryStorage storage;
 
-    auto [id, p] = storage.createPoint(1.5, -2.0);
+    const ID id = storage.createPoint(1.5, -2.0);
+    Point2D* p = storage.get<Point2D>(id);
     ASSERT_NE(p, nullptr);
 
     EXPECT_TRUE(storage.contains(id));
     EXPECT_EQ(storage.getType(id).value(), FigureType::ET_POINT2D);
     EXPECT_EQ(storage.getEntry(id)->type, FigureType::ET_POINT2D);
-    EXPECT_EQ(storage.getRaw(id), static_cast<void*>(p));
 
     auto point = storage.get<Point2D>(id);
     ASSERT_NE(point, nullptr);
@@ -31,19 +31,25 @@ TEST(GeometryStorageTest, CreatePointAndAccess) {
     EXPECT_EQ(storage.size(), 1u);
     EXPECT_EQ(storage.pointCount(), 1u);
     EXPECT_TRUE(storage.getIDsByType(FigureType::ET_POINT2D).size() == 1u);
-    EXPECT_TRUE(storage.allEntries().size() == 1u);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
 }
 
 TEST(GeometryStorageTest, CreateLineCircleArcAndDependencies) {
     GeometryStorage storage;
 
-    auto [p1Id, p1] = storage.createPoint(0.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(3.0, 0.0);
-    auto [cId, c] = storage.createPoint(1.0, 1.0);
+    const ID p1Id = storage.createPoint(0.0, 0.0);
+    const ID p2Id = storage.createPoint(3.0, 0.0);
+    const ID cId  = storage.createPoint(1.0, 1.0);
 
-    auto [lineId, line] = storage.createLine(p1, p2);
-    auto [circleId, circle] = storage.createCircle(c, 5.0);
-    auto [arcId, arc] = storage.createArc(p1, p2, c);
+    auto lineOpt = storage.createLine(p1Id, p2Id);
+    auto circleOpt = storage.createCircle(cId, 5.0);
+    auto arcOpt = storage.createArc(p1Id, p2Id, cId);
+    ASSERT_TRUE(lineOpt && circleOpt && arcOpt);
+    const ID lineId = *lineOpt;
+    const ID circleId = *circleOpt;
+    const ID arcId = *arcOpt;
 
     auto lineDeps = storage.getDependencies(lineId);
     EXPECT_EQ(lineDeps.size(), 2u);
@@ -69,6 +75,16 @@ TEST(GeometryStorageTest, CreateLineCircleArcAndDependencies) {
     EXPECT_EQ(cDependents.size(), 2u);
     EXPECT_TRUE(containsId(cDependents, circleId));
     EXPECT_TRUE(containsId(cDependents, arcId));
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
+}
+
+TEST(GeometryStorageTest, CreateLineInvalidIds) {
+    GeometryStorage storage;
+    const ID a = storage.createPoint(0, 0);
+    EXPECT_FALSE(storage.createLine(a, ID(999)).has_value());
+    EXPECT_FALSE(storage.createLine(ID(999), a).has_value());
 }
 
 TEST(GeometryStorageTest, CreateFigureFromData) {
@@ -97,6 +113,9 @@ TEST(GeometryStorageTest, CreateFigureFromData) {
     arcData.center = {1.0, 1.0};
     auto arcId = storage.createFigure(FigureType::ET_ARC, arcData);
     EXPECT_EQ(storage.getType(arcId).value(), FigureType::ET_ARC);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
 }
 
 TEST(GeometryStorageTest, CreateFigureInvalidData) {
@@ -115,21 +134,26 @@ TEST(GeometryStorageTest, CreateFigureInvalidData) {
 TEST(GeometryStorageTest, RemoveAndCascade) {
     GeometryStorage storage;
 
-    auto [p1Id, p1] = storage.createPoint(0.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(1.0, 0.0);
-    auto [lineId, line] = storage.createLine(p1, p2);
+    const ID p1Id = storage.createPoint(0.0, 0.0);
+    const ID p2Id = storage.createPoint(1.0, 0.0);
+    auto lineOpt = storage.createLine(p1Id, p2Id);
+    ASSERT_TRUE(lineOpt);
+    const ID lineId = *lineOpt;
 
-    EXPECT_THROW(storage.remove(p1Id, false), std::runtime_error);
+    EXPECT_EQ(storage.remove(p1Id, false), RemoveResult::BlockedByDependents);
 
-    storage.remove(p1Id, true);
+    EXPECT_EQ(storage.remove(p1Id, true), RemoveResult::Ok);
     EXPECT_FALSE(storage.contains(p1Id));
     EXPECT_FALSE(storage.contains(lineId));
     EXPECT_TRUE(storage.contains(p2Id));
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
 }
 
 TEST(GeometryStorageTest, RemoveNotFound) {
     GeometryStorage storage;
-    EXPECT_THROW(storage.remove(ID(123)), std::runtime_error);
+    EXPECT_EQ(storage.remove(ID(123)), RemoveResult::NotFound);
 }
 
 TEST(GeometryStorageTest, ClearAndStats) {
@@ -138,8 +162,8 @@ TEST(GeometryStorageTest, ClearAndStats) {
     EXPECT_TRUE(storage.empty());
     EXPECT_EQ(storage.currentID().id, 1ull);
 
-    [[maybe_unused]] auto _p1 = storage.createPoint(0.0, 0.0);
-    [[maybe_unused]] auto _p2 = storage.createPoint(1.0, 1.0);
+    (void)storage.createPoint(0.0, 0.0);
+    (void)storage.createPoint(1.0, 1.0);
     EXPECT_FALSE(storage.empty());
     EXPECT_EQ(storage.pointCount(), 2u);
     EXPECT_EQ(storage.currentID().id, 3ull);
@@ -157,39 +181,41 @@ TEST(GeometryStorageTest, ClearAndStats) {
 TEST(GeometryStorageTest, SpansAndCounts) {
     GeometryStorage storage;
 
-    EXPECT_TRUE(storage.allPoints().empty());
-    EXPECT_TRUE(storage.allLines().empty());
-    EXPECT_TRUE(storage.allCircles().empty());
-    EXPECT_TRUE(storage.allArcs().empty());
+    EXPECT_TRUE(storage.pointsWithIds().empty());
+    EXPECT_TRUE(storage.linesWithIds().empty());
+    EXPECT_TRUE(storage.circlesWithIds().empty());
+    EXPECT_TRUE(storage.arcsWithIds().empty());
 
-    auto [p1Id, p1] = storage.createPoint(0.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(1.0, 0.0);
-    auto [cId, c] = storage.createPoint(2.0, 2.0);
-    [[maybe_unused]] auto _line = storage.createLine(p1, p2);
-    [[maybe_unused]] auto _circle = storage.createCircle(c, 3.0);
-    [[maybe_unused]] auto _arc = storage.createArc(p1, p2, c);
-
-    EXPECT_EQ(storage.allPoints().size(), 3u);
-    EXPECT_EQ(storage.allLines().size(), 1u);
-    EXPECT_EQ(storage.allCircles().size(), 1u);
-    EXPECT_EQ(storage.allArcs().size(), 1u);
+    const ID p1Id = storage.createPoint(0.0, 0.0);
+    const ID p2Id = storage.createPoint(1.0, 0.0);
+    const ID cId  = storage.createPoint(2.0, 2.0);
+    ASSERT_TRUE(storage.createLine(p1Id, p2Id).has_value());
+    ASSERT_TRUE(storage.createCircle(cId, 3.0).has_value());
+    ASSERT_TRUE(storage.createArc(p1Id, p2Id, cId).has_value());
 
     EXPECT_EQ(storage.pointCount(), 3u);
     EXPECT_EQ(storage.lineCount(), 1u);
     EXPECT_EQ(storage.circleCount(), 1u);
     EXPECT_EQ(storage.arcCount(), 1u);
+#ifndef NDEBUG
+    EXPECT_TRUE(storage.validate());
+#endif
 }
 
 TEST(GeometryStorageTest, BuildObjectGraph) {
     GeometryStorage storage;
 
-    auto [p1Id, p1] = storage.createPoint(0.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(1.0, 0.0);
-    auto [cId, c] = storage.createPoint(2.0, 2.0);
+    const ID p1Id = storage.createPoint(0.0, 0.0);
+    const ID p2Id = storage.createPoint(1.0, 0.0);
+    const ID cId  = storage.createPoint(2.0, 2.0);
 
-    auto [lineId, line] = storage.createLine(p1, p2);
-    auto [circleId, circle] = storage.createCircle(c, 3.0);
-    auto [arcId, arc] = storage.createArc(p1, p2, c);
+    auto lineOpt = storage.createLine(p1Id, p2Id);
+    auto circleOpt = storage.createCircle(cId, 3.0);
+    auto arcOpt = storage.createArc(p1Id, p2Id, cId);
+    ASSERT_TRUE(lineOpt && circleOpt && arcOpt);
+    const ID lineId = *lineOpt;
+    const ID circleId = *circleOpt;
+    const ID arcId = *arcOpt;
 
     auto graph = storage.buildObjectGraph();
 
@@ -206,37 +232,45 @@ TEST(GeometryStorageTest, BuildObjectGraph) {
 TEST(GeometryStorageTest, BuildObjectSubgraph) {
     GeometryStorage storage;
 
-    auto [p1Id, p1] = storage.createPoint(0.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(1.0, 0.0);
-    auto [lineId, line] = storage.createLine(p1, p2);
-    auto [p3Id, p3] = storage.createPoint(5.0, 5.0);
+    const ID p1Id = storage.createPoint(0.0, 0.0);
+    const ID p2Id = storage.createPoint(1.0, 0.0);
+    auto lineOpt = storage.createLine(p1Id, p2Id);
+    ASSERT_TRUE(lineOpt);
+    const ID lineId = *lineOpt;
+    const ID p3Id = storage.createPoint(5.0, 5.0);
 
     auto subgraph = storage.buildObjectSubgraph(lineId);
-    EXPECT_EQ(subgraph.vertexCount(), 3u);
-    EXPECT_TRUE(subgraph.hasEdge(lineId, p1Id));
-    EXPECT_TRUE(subgraph.hasEdge(lineId, p2Id));
+    ASSERT_TRUE(subgraph.has_value());
+    EXPECT_EQ(subgraph->vertexCount(), 3u);
+    EXPECT_TRUE(subgraph->hasEdge(lineId, p1Id));
+    EXPECT_TRUE(subgraph->hasEdge(lineId, p2Id));
 
     auto pointGraph = storage.buildObjectSubgraph(p1Id);
-    EXPECT_EQ(pointGraph.vertexCount(), 3u);
-    EXPECT_TRUE(pointGraph.hasEdge(p1Id, lineId));
-    EXPECT_TRUE(pointGraph.hasEdge(lineId, p2Id));
+    ASSERT_TRUE(pointGraph.has_value());
+    EXPECT_EQ(pointGraph->vertexCount(), 3u);
+    EXPECT_TRUE(pointGraph->hasEdge(p1Id, lineId));
+    EXPECT_TRUE(pointGraph->hasEdge(lineId, p2Id));
 
     auto isolated = storage.buildObjectSubgraph(p3Id);
-    EXPECT_EQ(isolated.vertexCount(), 1u);
-    EXPECT_FALSE(isolated.hasEdge(p3Id, p3Id));
+    ASSERT_TRUE(isolated.has_value());
+    EXPECT_EQ(isolated->vertexCount(), 1u);
+    EXPECT_FALSE(isolated->hasEdge(p3Id, p3Id));
 
-    EXPECT_THROW(storage.buildObjectSubgraph(ID(999)), std::runtime_error);
+    EXPECT_FALSE(storage.buildObjectSubgraph(ID(999)).has_value());
 }
 
 TEST(GeometryStorageTest, SharedPointBetweenLines) {
     GeometryStorage storage;
 
-    auto [pSharedId, pShared] = storage.createPoint(0.0, 0.0);
-    auto [p1Id, p1] = storage.createPoint(1.0, 0.0);
-    auto [p2Id, p2] = storage.createPoint(2.0, 0.0);
+    const ID pSharedId = storage.createPoint(0.0, 0.0);
+    const ID p1Id = storage.createPoint(1.0, 0.0);
+    const ID p2Id = storage.createPoint(2.0, 0.0);
 
-    auto [line1Id, line1] = storage.createLine(pShared, p1);
-    auto [line2Id, line2] = storage.createLine(pShared, p2);
+    auto l1 = storage.createLine(pSharedId, p1Id);
+    auto l2 = storage.createLine(pSharedId, p2Id);
+    ASSERT_TRUE(l1 && l2);
+    const ID line1Id = *l1;
+    const ID line2Id = *l2;
 
     auto dependents = storage.getDependents(pSharedId);
     EXPECT_EQ(dependents.size(), 2u);
@@ -244,21 +278,44 @@ TEST(GeometryStorageTest, SharedPointBetweenLines) {
     EXPECT_TRUE(std::find(dependents.begin(), dependents.end(), line2Id) != dependents.end());
 
     auto subgraph = storage.buildObjectSubgraph(pSharedId);
-    EXPECT_EQ(subgraph.vertexCount(), 5u);
-    EXPECT_TRUE(subgraph.hasEdge(pSharedId, line1Id));
-    EXPECT_TRUE(subgraph.hasEdge(pSharedId, line2Id));
-    EXPECT_TRUE(subgraph.hasEdge(line1Id, p1Id));
-    EXPECT_TRUE(subgraph.hasEdge(line2Id, p2Id));
+    ASSERT_TRUE(subgraph.has_value());
+    EXPECT_EQ(subgraph->vertexCount(), 5u);
+    EXPECT_TRUE(subgraph->hasEdge(pSharedId, line1Id));
+    EXPECT_TRUE(subgraph->hasEdge(pSharedId, line2Id));
+    EXPECT_TRUE(subgraph->hasEdge(line1Id, p1Id));
+    EXPECT_TRUE(subgraph->hasEdge(line2Id, p2Id));
 }
 
 TEST(GeometryStorageTest, GetTypeMismatch) {
     GeometryStorage storage;
-    auto [id, p] = storage.createPoint(0.0, 0.0);
-    EXPECT_THROW((void)storage.get<Line2D>(id), std::runtime_error);
+    const ID id = storage.createPoint(0.0, 0.0);
+    EXPECT_EQ(storage.get<Line2D>(id), nullptr);
 }
 
 TEST(GeometryStorageTest, GetNotFound) {
     GeometryStorage storage;
-    EXPECT_THROW((void)storage.get<Point2D>(ID(999)), std::runtime_error);
+    EXPECT_EQ(storage.get<Point2D>(ID(999)), nullptr);
 }
 
+#ifndef NDEBUG
+TEST(GeometryStorageTest, SlotReuse_NoUnboundedGrowth) {
+    GeometryStorage storage;
+    for (int k = 0; k < 5; ++k) {
+        const ID p = storage.createPoint(1.0, 2.0);
+        EXPECT_EQ(storage.remove(p, false), RemoveResult::Ok);
+    }
+    EXPECT_LE(storage.debugPointPoolSize(), 2u);
+    EXPECT_TRUE(storage.validate());
+}
+
+TEST(GeometryStorageTest, ValidateAfterStress) {
+    GeometryStorage storage;
+    const ID a = storage.createPoint(0, 0);
+    const ID b = storage.createPoint(1, 0);
+    auto line = storage.createLine(a, b);
+    ASSERT_TRUE(line);
+    EXPECT_TRUE(storage.validate());
+    EXPECT_EQ(storage.remove(a, true), RemoveResult::Ok);
+    EXPECT_TRUE(storage.validate());
+}
+#endif

--- a/tests/System/FixRequirementSystemGTEST.cpp
+++ b/tests/System/FixRequirementSystemGTEST.cpp
@@ -15,19 +15,17 @@ protected:
     ID circleId;
 
     void SetUp() override {
-        auto [id1, pt1] = storage.createPoint(1.0, 2.0);
-        auto [id2, pt2] = storage.createPoint(5.0, 6.0);
-        auto [id3, pt3] = storage.createPoint(3.0, 4.0);
+        p1Id = storage.createPoint(1.0, 2.0);
+        p2Id = storage.createPoint(5.0, 6.0);
+        centerId = storage.createPoint(3.0, 4.0);
 
-        p1Id = id1;
-        p2Id = id2;
-        centerId = id3;
+        auto lineOpt = storage.createLine(p1Id, p2Id);
+        ASSERT_TRUE(lineOpt.has_value());
+        lineId = *lineOpt;
 
-        auto [lid, l] = storage.createLine(pt1, pt2);
-        lineId = lid;
-
-        auto [cid, c] = storage.createCircle(pt3, 7.5);
-        circleId = cid;
+        auto circOpt = storage.createCircle(centerId, 7.5);
+        ASSERT_TRUE(circOpt.has_value());
+        circleId = *circOpt;
     }
 };
 

--- a/tests/System/RequirementSystemGTEST.cpp
+++ b/tests/System/RequirementSystemGTEST.cpp
@@ -15,26 +15,25 @@ protected:
     ID arcId;
 
     void SetUp() override {
-        auto [id1, pt1] = storage.createPoint(0.0, 0.0);
-        auto [id2, pt2] = storage.createPoint(3.0, 4.0);
-        auto [id3, pt3] = storage.createPoint(6.0, 0.0);
-        auto [id4, pt4] = storage.createPoint(5.0, 5.0);
+        p1Id = storage.createPoint(0.0, 0.0);
+        p2Id = storage.createPoint(3.0, 4.0);
+        p3Id = storage.createPoint(6.0, 0.0);
+        centerId = storage.createPoint(5.0, 5.0);
 
-        p1Id = id1;
-        p2Id = id2;
-        p3Id = id3;
-        centerId = id4;
+        auto line1Opt = storage.createLine(p1Id, p2Id);
+        auto line2Opt = storage.createLine(p2Id, p3Id);
+        ASSERT_TRUE(line1Opt.has_value());
+        ASSERT_TRUE(line2Opt.has_value());
+        line1Id = *line1Opt;
+        line2Id = *line2Opt;
 
-        auto [lid1, l1] = storage.createLine(pt1, pt2);
-        auto [lid2, l2] = storage.createLine(pt2, pt3);
-        line1Id = lid1;
-        line2Id = lid2;
+        auto circOpt = storage.createCircle(centerId, 10.0);
+        ASSERT_TRUE(circOpt.has_value());
+        circleId = *circOpt;
 
-        auto [cid, c] = storage.createCircle(pt4, 10.0);
-        circleId = cid;
-
-        auto [aid, a] = storage.createArc(pt1, pt3, pt4);
-        arcId = aid;
+        auto arcOpt = storage.createArc(p1Id, p3Id, centerId);
+        ASSERT_TRUE(arcOpt.has_value());
+        arcId = *arcOpt;
     }
 };
 

--- a/tests/function/FixCoordinateFunctionGTEST.cpp
+++ b/tests/function/FixCoordinateFunctionGTEST.cpp
@@ -83,7 +83,9 @@ TEST(FixCoordinateFunctionTest, TracksVariableChanges) {
 
 TEST(FixCoordinateFactoryTest, CreateFixPoint) {
     GeometryStorage storage;
-    auto [id, pt] = storage.createPoint(3.0, 4.0);
+    const ID id = storage.createPoint(3.0, 4.0);
+    Point2D* pt = storage.get<Point2D>(id);
+    ASSERT_NE(pt, nullptr);
     auto funcs = RequirementFunctionFactory::createFixPoint(pt);
 
     ASSERT_EQ(funcs.size(), 2u);
@@ -97,7 +99,9 @@ TEST(FixCoordinateFactoryTest, CreateFixPoint) {
 
 TEST(FixCoordinateFactoryTest, CreateFixPointDetectsMovement) {
     GeometryStorage storage;
-    auto [id, pt] = storage.createPoint(3.0, 4.0);
+    const ID id = storage.createPoint(3.0, 4.0);
+    Point2D* pt = storage.get<Point2D>(id);
+    ASSERT_NE(pt, nullptr);
     auto funcs = RequirementFunctionFactory::createFixPoint(pt);
 
     pt->x() = 10.0;
@@ -108,9 +112,14 @@ TEST(FixCoordinateFactoryTest, CreateFixPointDetectsMovement) {
 
 TEST(FixCoordinateFactoryTest, CreateFixLine) {
     GeometryStorage storage;
-    auto [id1, pt1] = storage.createPoint(1.0, 2.0);
-    auto [id2, pt2] = storage.createPoint(5.0, 6.0);
-    auto [lid, line] = storage.createLine(pt1, pt2);
+    const ID id1 = storage.createPoint(1.0, 2.0);
+    const ID id2 = storage.createPoint(5.0, 6.0);
+    Point2D* pt1 = storage.get<Point2D>(id1);
+    Point2D* pt2 = storage.get<Point2D>(id2);
+    auto lineOpt = storage.createLine(id1, id2);
+    ASSERT_TRUE(lineOpt.has_value());
+    Line2D* line = storage.get<Line2D>(*lineOpt);
+    ASSERT_NE(line, nullptr);
 
     auto funcs = RequirementFunctionFactory::createFixLine(line);
     ASSERT_EQ(funcs.size(), 4u);
@@ -127,9 +136,14 @@ TEST(FixCoordinateFactoryTest, CreateFixLine) {
 
 TEST(FixCoordinateFactoryTest, CreateFixLineDetectsMovement) {
     GeometryStorage storage;
-    auto [id1, pt1] = storage.createPoint(1.0, 2.0);
-    auto [id2, pt2] = storage.createPoint(5.0, 6.0);
-    auto [lid, line] = storage.createLine(pt1, pt2);
+    const ID id1 = storage.createPoint(1.0, 2.0);
+    const ID id2 = storage.createPoint(5.0, 6.0);
+    Point2D* pt1 = storage.get<Point2D>(id1);
+    Point2D* pt2 = storage.get<Point2D>(id2);
+    auto lineOpt = storage.createLine(id1, id2);
+    ASSERT_TRUE(lineOpt.has_value());
+    Line2D* line = storage.get<Line2D>(*lineOpt);
+    ASSERT_NE(line, nullptr);
 
     auto funcs = RequirementFunctionFactory::createFixLine(line);
 
@@ -141,8 +155,13 @@ TEST(FixCoordinateFactoryTest, CreateFixLineDetectsMovement) {
 
 TEST(FixCoordinateFactoryTest, CreateFixCircle) {
     GeometryStorage storage;
-    auto [cid, center] = storage.createPoint(3.0, 4.0);
-    auto [circId, circle] = storage.createCircle(center, 7.5);
+    const ID cid = storage.createPoint(3.0, 4.0);
+    Point2D* center = storage.get<Point2D>(cid);
+    ASSERT_NE(center, nullptr);
+    auto circOpt = storage.createCircle(cid, 7.5);
+    ASSERT_TRUE(circOpt.has_value());
+    Circle2D* circle = storage.get<Circle2D>(*circOpt);
+    ASSERT_NE(circle, nullptr);
 
     auto funcs = RequirementFunctionFactory::createFixCircle(circle);
     ASSERT_EQ(funcs.size(), 3u);
@@ -158,8 +177,13 @@ TEST(FixCoordinateFactoryTest, CreateFixCircle) {
 
 TEST(FixCoordinateFactoryTest, CreateFixCircleDetectsMovement) {
     GeometryStorage storage;
-    auto [cid, center] = storage.createPoint(3.0, 4.0);
-    auto [circId, circle] = storage.createCircle(center, 7.5);
+    const ID cid = storage.createPoint(3.0, 4.0);
+    Point2D* center = storage.get<Point2D>(cid);
+    ASSERT_NE(center, nullptr);
+    auto circOpt = storage.createCircle(cid, 7.5);
+    ASSERT_TRUE(circOpt.has_value());
+    Circle2D* circle = storage.get<Circle2D>(*circOpt);
+    ASSERT_NE(circle, nullptr);
 
     auto funcs = RequirementFunctionFactory::createFixCircle(circle);
 

--- a/tests/function/RequirementFunctionFactoryGTEST.cpp
+++ b/tests/function/RequirementFunctionFactoryGTEST.cpp
@@ -18,26 +18,30 @@ protected:
     Arc2D* arc;
 
     void SetUp() override {
-        auto [id1, pt1] = storage.createPoint(0.0, 0.0);
-        auto [id2, pt2] = storage.createPoint(3.0, 4.0);
-        auto [id3, pt3] = storage.createPoint(6.0, 0.0);
-        auto [id4, pt4] = storage.createPoint(5.0, 5.0);
+        const ID id1 = storage.createPoint(0.0, 0.0);
+        const ID id2 = storage.createPoint(3.0, 4.0);
+        const ID id3 = storage.createPoint(6.0, 0.0);
+        const ID id4 = storage.createPoint(5.0, 5.0);
 
-        p1 = pt1;
-        p2 = pt2;
-        p3 = pt3;
-        center = pt4;
+        p1 = storage.get<Point2D>(id1);
+        p2 = storage.get<Point2D>(id2);
+        p3 = storage.get<Point2D>(id3);
+        center = storage.get<Point2D>(id4);
 
-        auto [lid1, l1] = storage.createLine(p1, p2);
-        auto [lid2, l2] = storage.createLine(p2, p3);
-        line1 = l1;
-        line2 = l2;
+        auto lid1 = storage.createLine(id1, id2);
+        auto lid2 = storage.createLine(id2, id3);
+        ASSERT_TRUE(lid1.has_value());
+        ASSERT_TRUE(lid2.has_value());
+        line1 = storage.get<Line2D>(*lid1);
+        line2 = storage.get<Line2D>(*lid2);
 
-        auto [cid, c] = storage.createCircle(center, 10.0);
-        circle = c;
+        auto cid = storage.createCircle(id4, 10.0);
+        ASSERT_TRUE(cid.has_value());
+        circle = storage.get<Circle2D>(*cid);
 
-        auto [aid, a] = storage.createArc(p1, p3, center);
-        arc = a;
+        auto aid = storage.createArc(id1, id3, id4);
+        ASSERT_TRUE(aid.has_value());
+        arc = storage.get<Arc2D>(*aid);
     }
 };
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added queries to list figures by type (points, lines, circles, arcs) returning full descriptors with IDs.
* **Behavior Changes**
  * Creation and removal now report explicit success/failure and handle missing or invalid references more safely; counts reflect canonical storage.
* **Documentation**
  * Clarified read-only vs. mutable storage access and warned about unsafe direct mutation.
* **Tests**
  * Added a unit test verifying retrieval of all points and their coordinates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->